### PR TITLE
Use boolean over "true" and "false" strings

### DIFF
--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -63,27 +63,27 @@ export interface JDBCOptions {
   // Other properties
   "full open"?: boolean;
   "access"?: "all" | "read call" | "read only";
-  "autocommit exception"?: "true" | "false";
+  "autocommit exception"?: boolean;
   "bidi string type"?: "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11";
-  "bidi implicit reordering"?: "true" | "false";
-  "bidi numeric ordering"?: "true" | "false";
-  "data truncation"?: "true" | "false";
+  "bidi implicit reordering"?: boolean;
+  "bidi numeric ordering"?: boolean;
+  "data truncation"?: boolean;
   "driver"?: "toolbox" | "native";
   "errors"?: "full" | "basic";
-  "extended metadata"?: "true" | "false";
-  "hold input locators"?: "true" | "false";
-  "hold statements"?: "true" | "false";
+  "extended metadata"?: boolean;
+  "hold input locators"?: boolean;
+  "hold statements"?: boolean;
   "ignore warnings"?: string;
-  "keep alive"?: "true" | "false";
+  "keep alive"?: boolean;
   "key ring name"?: string;
   "key ring password"?: string;
   "metadata source"?: "0" | "1";
   "proxy server"?: string;
   "remarks"?: "sql" | "system";
   "secondary URL"?: string;
-  "secure"?: "true" | "false";
+  "secure"?: boolean;
   "server trace"?: "0" | "2" | "4" | "8" | "16" | "32" | "64";
-  "thread used"?: "true" | "false";
+  "thread used"?: boolean;
   "toolbox trace"?:
     | ""
     | "none"
@@ -98,15 +98,15 @@ export interface JDBCOptions {
     | "proxy"
     | "thread"
     | "information";
-  "trace"?: "true" | "false";
-  "translate binary"?: "true" | "false";
-  "translate boolean"?: "true" | "false";
+  "trace"?: boolean;
+  "translate binary"?: boolean;
+  "translate boolean"?: boolean;
 
   // System Properties
   "libraries"?: string[];
-  "auto commit"?: "true" | "false";
+  "auto commit"?: boolean;
   "concurrent access resolution"?: "1" | "2" | "3";
-  "cursor hold"?: "true" | "false";
+  "cursor hold"?: boolean;
   "cursor sensitivity"?: "asensitive" | "insensitive" | "sensitive";
   "database name"?: string;
   "decfloat rounding mode"?:
@@ -138,32 +138,32 @@ export interface JDBCOptions {
     | "repeatable read"
     | "serializable";
   "translate hex"?: "character" | "binary";
-  "true autocommit"?: "true" | "false";
+  "true autocommit"?: boolean;
   "XA loosely coupled support"?: "0" | "1";
 
   // Performance Properties
-  "big decimal"?: "true" | "false";
+  "big decimal"?: boolean;
   "block criteria"?: "0" | "1" | "2";
   "block size"?: "0" | "8" | "16" | "32" | "64" | "128" | "256" | "512";
-  "data compression"?: "true" | "false";
-  "extended dynamic"?: "true" | "false";
-  "lazy close"?: "true" | "false";
+  "data compression"?: boolean;
+  "extended dynamic"?: boolean;
+  "lazy close"?: boolean;
   "lob threshold"?: string;
   "maximum blocked input rows"?: string;
   "package"?: string;
-  "package add"?: "true" | "false";
-  "package cache"?: "true" | "false";
+  "package add"?: boolean;
+  "package cache"?: boolean;
   "package criteria"?: "default" | "select";
   "package error"?: "exception" | "warning" | "none";
   "package library"?: string;
-  "prefetch"?: "true" | "false";
+  "prefetch"?: boolean;
   "qaqqinilib"?: string;
   "query optimize goal"?: "0" | "1" | "2";
   "query timeout mechanism"?: "qqrytimlmt" | "cancel";
   "query storage limit"?: string;
   "receive buffer size"?: string;
   "send buffer size"?: string;
-  "vairiable field compression"?: "true" | "false";
+  "vairiable field compression"?: boolean;
 
   // Sort Properties
   "sort"?: "hex" | "language" | "table";

--- a/src/views/jobManager/editJob/index.ts
+++ b/src/views/jobManager/editJob/index.ts
@@ -57,14 +57,17 @@ export async function editJobUi(
           case `libraries`:
             options.libraries = page.data[key].split(`,`).map((v) => v.trim());
             break;
-          case `full open`:
-            options["full open"] = page.data[key] === `true`;
-            break;
           case `buttons`:
             // Do nothing with buttons
             break;
+            
           default:
-            options[key] = page.data[key];
+            // Handle of true/false values back into boolean types
+            switch (page.data[key]) {
+              case `true`: options[key] = true; break;
+              case `false`: options[key] = false; break;
+              default: options[key] = page.data[key]; break;
+            }
         }
       }
 

--- a/src/views/jobManager/editJob/otherTab.ts
+++ b/src/views/jobManager/editJob/otherTab.ts
@@ -90,13 +90,13 @@ export default function getOtherTab(options: JDBCOptions) {
         value: `false`,
         text: `Do not throw an exception when autocommit is set to true`,
         description: `False`,
-        selected: options["autocommit exception"] !== `true`,
+        selected: options["autocommit exception"] !== true,
       },
       {
         value: `true`,
         text: `Throw an exception when autocommit is set to true`,
         description: `True`,
-        selected: options["autocommit exception"] === `true`,
+        selected: options["autocommit exception"] === true,
       },
     ])
     .addSelect(
@@ -162,13 +162,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `true`,
           text: `Perform implicit reordering`,
           description: `True`,
-          selected: options["bidi implicit reordering"] === `true`,
+          selected: options["bidi implicit reordering"] === true,
         },
         {
           value: `false`,
           text: `Do not perform implicit reordering`,
           description: `False`,
-          selected: options["bidi implicit reordering"] !== `true`,
+          selected: options["bidi implicit reordering"] !== true,
         },
       ],
       `Specifies if bidi implicit LTR-RTL reordering should be used.`
@@ -181,13 +181,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `false`,
           text: `Do not perform numeric ordering`,
           description: `False`,
-          selected: options["bidi numeric ordering"] !== `true`,
+          selected: options["bidi numeric ordering"] !== true,
         },
         {
           value: `true`,
           text: `Perform numeric ordering`,
           description: `True`,
-          selected: options["bidi numeric ordering"] === `true`,
+          selected: options["bidi numeric ordering"] === true,
         },
       ],
       `Specifies if the numeric ordering round trip feature should be used.`
@@ -200,13 +200,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `true`,
           text: `true`,
           description: `True`,
-          selected: options["data truncation"] === `true`,
+          selected: options["data truncation"] === true,
         },
         {
           value: `false`,
           text: `false`,
           description: `False`,
-          selected: options["data truncation"] !== `true`,
+          selected: options["data truncation"] !== true,
         },
       ],
       formatDescription(dataTruncationText)
@@ -257,13 +257,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `false`,
           text: `false`,
           description: `False`,
-          selected: options["extended metadata"] !== `true`,
+          selected: options["extended metadata"] !== true,
         },
         {
           value: `true`,
           text: `true`,
           description: `True`,
-          selected: options["extended metadata"] === `true`,
+          selected: options["extended metadata"] === true,
         },
       ],
       formatDescription(extendedMetaDataText)
@@ -276,13 +276,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `true`,
           text: `true (type hold)`,
           description: `True`,
-          selected: options["hold input locators"] === `true`,
+          selected: options["hold input locators"] === true,
         },
         {
           value: `false`,
           text: `false`,
           description: `False`,
-          selected: options["hold input locators"] !== `true`,
+          selected: options["hold input locators"] !== true,
         },
       ],
       `Specifies whether input locators should be allocated as type hold locators or not hold locators. If the locators are of type hold, they will not be released when a commit is done.`
@@ -295,13 +295,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `true`,
           text: `true`,
           description: `True`,
-          selected: options["hold statements"] === `true`,
+          selected: options["hold statements"] === true,
         },
         {
           value: `false`,
           text: `false`,
           description: `False`,
-          selected: options["hold statements"] !== `true`,
+          selected: options["hold statements"] !== true,
         },
       ],
       `Specifies if statements should remain open until a transaction boundary when autocommit is off and they are associated with a LOB locator. By default, all the resources associated with a statement are released when the statement is closed. Set this property to true only when access to a LOB locator is needed after a statement has been closed.`
@@ -373,13 +373,13 @@ export default function getOtherTab(options: JDBCOptions) {
         value: `false`,
         text: `encrypt only the password`,
         description: `False`,
-        selected: options["secure"] !== `true`,
+        selected: options["secure"] !== true,
       },
       {
         value: `true`,
         text: `encrypt all client/server communication`,
         description: `True`,
-        selected: options["secure"] === `true`,
+        selected: options["secure"] === true,
       },
     ])
     .addSelect(
@@ -436,13 +436,13 @@ export default function getOtherTab(options: JDBCOptions) {
         value: `true`,
         text: `true`,
         description: `True`,
-        selected: options["thread used"] === `true`,
+        selected: options["thread used"] === true,
       },
       {
         value: `false`,
         text: `false`,
         description: `False`,
-        selected: options["thread used"] !== `true`,
+        selected: options["thread used"] !== true,
       },
     ])
     .addSelect(
@@ -538,13 +538,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `false`,
           text: `trace is not active`,
           description: `False`,
-          selected: options["trace"] !== `true`,
+          selected: options["trace"] !== true,
         },
         {
           value: `true`,
           text: `trace is active`,
           description: `True`,
-          selected: options["trace"] === `true`,
+          selected: options["trace"] === true,
         },
       ],
       `	Specifies whether trace messages should be logged. Trace messages are useful for debugging programs that call JDBC. However, there is a performance penalty associated with logging trace messages, so this property should only be set to "true" for debugging. Trace messages are logged to System.out.`
@@ -557,13 +557,13 @@ export default function getOtherTab(options: JDBCOptions) {
           value: `false`,
           text: `false`,
           description: `False`,
-          selected: options["translate binary"] !== `true`,
+          selected: options["translate binary"] !== true,
         },
         {
           value: `true`,
           text: `true`,
           description: `True`,
-          selected: options["translate binary"] === `true`,
+          selected: options["translate binary"] === true,
         },
       ],
       `Specifies whether binary data is translated. If this property is set to "true", then BINARY and VARBINARY fields are treated as CHAR and VARCHAR fields.`
@@ -573,13 +573,13 @@ export default function getOtherTab(options: JDBCOptions) {
         value: `true`,
         text: `true`,
         description: `True`,
-        selected: options["translate boolean"] === `true`,
+        selected: options["translate boolean"] === true,
       },
       {
         value: `false`,
         text: `false`,
         description: `False`,
-        selected: options["translate boolean"] !== `true`,
+        selected: options["translate boolean"] !== true,
       },
     ])
     .addInput(

--- a/src/views/jobManager/editJob/perfTab.ts
+++ b/src/views/jobManager/editJob/perfTab.ts
@@ -17,13 +17,13 @@ export default function getPerfTab(options: JDBCOptions) {
           value: `true`,
           text: `Use big decimal`,
           description: `True`,
-          selected: options["big decimal"] === `true`,
+          selected: options["big decimal"] === true,
         },
         {
           value: `false`,
           text: `Do not use big decimal`,
           description: `False`,
-          selected: options["big decimal"] === `false`,
+          selected: options["big decimal"] === false,
         },
       ],
       `Specifies whether an intermediate java.math.BigDecimal object is used for packed and zoned decimal conversions. If this property is set to "true", 
@@ -118,13 +118,13 @@ export default function getPerfTab(options: JDBCOptions) {
           value: `true`,
           text: `Use data compression`,
           description: `True`,
-          selected: options["data compression"] === `true`,
+          selected: options["data compression"] === true,
         },
         {
           value: `false`,
           text: `Do not use data compression`,
           description: `False`,
-          selected: options["data compression"] === `false`,
+          selected: options["data compression"] === false,
         },
       ],
       `Specifies whether result set data is compressed. If this property is set to "true", then result set data is compressed. If this property is set to "false", then result set data is not compressed. Data compression may improve performance when retrieving large result sets.`
@@ -137,13 +137,13 @@ export default function getPerfTab(options: JDBCOptions) {
           value: `false`,
           text: `Do not use extended dynamic`,
           description: `False`,
-          selected: options["extended dynamic"] === `false`,
+          selected: options["extended dynamic"] === false,
         },
         {
           value: `true`,
           text: `Use extended dynamic`,
           description: `True`,
-          selected: options["extended dynamic"] === `true`,
+          selected: options["extended dynamic"] === true,
         },
       ],
       `Specifies whether to use extended dynamic support. Extended dynamic support provides a mechanism for caching dynamic SQL statements on the system. The first time a particular SQL statement is prepared, it is stored in a SQL package on the system. If the package does not exist, it is automatically created. On subsequent prepares of the same SQL statement, the system can skip a significant part of the processing by using information stored in the SQL package. If this is set to "true", then a package name must be set using the "package" property.`
@@ -156,13 +156,13 @@ export default function getPerfTab(options: JDBCOptions) {
           value: `false`,
           text: `Do not use lazy close`,
           description: `False`,
-          selected: options["lazy close"] === `false`,
+          selected: options["lazy close"] === false,
         },
         {
           value: `true`,
           text: `Use lazy close`,
           description: `True`,
-          selected: options["lazy close"] === `true`,
+          selected: options["lazy close"] === true,
         },
       ],
       `Specifies whether to delay closing cursors until subsequent requests. This will increase overall performance by reducing the total number of requests.`
@@ -191,13 +191,13 @@ export default function getPerfTab(options: JDBCOptions) {
         value: `true`,
         text: `Add to package`,
         description: `True`,
-        selected: options["package add"] === `true`,
+        selected: options["package add"] === true,
       },
       {
         value: `false`,
         text: `Do not add to package`,
         description: `False`,
-        selected: options["package add"] === `false`,
+        selected: options["package add"] === false,
       },
     ])
     .addSelect(`package cache`, `Package cache`, [
@@ -205,13 +205,13 @@ export default function getPerfTab(options: JDBCOptions) {
         value: `false`,
         text: `Do not use package cache`,
         description: `False`,
-        selected: options["package cache"] === `false`,
+        selected: options["package cache"] === false,
       },
       {
         value: `true`,
         text: `Use package cache`,
         description: `True`,
-        selected: options["package cache"] === `true`,
+        selected: options["package cache"] === true,
       },
     ])
     .addSelect(`package criteria`, `Package criteria`, [
@@ -259,13 +259,13 @@ export default function getPerfTab(options: JDBCOptions) {
         value: `true`,
         text: `Use prefetch`,
         description: `True`,
-        selected: options["prefetch"] === `true`,
+        selected: options["prefetch"] === true,
       },
       {
         value: `false`,
         text: `Do not use prefetch`,
         description: `False`,
-        selected: options["prefetch"] === `false`,
+        selected: options["prefetch"] === false,
       },
     ])
     .addInput(
@@ -326,13 +326,13 @@ export default function getPerfTab(options: JDBCOptions) {
         value: `true`,
         text: `Use variable field compression`,
         description: `True`,
-        selected: options["variable field compression"] === `true`,
+        selected: options["variable field compression"] === true,
       },
       {
         value: `false`,
         text: `Do not use variable field compression`,
         description: `False`,
-        selected: options["variable field compression"] === `false`,
+        selected: options["variable field compression"] === false,
       },
     ]);
 

--- a/src/views/jobManager/editJob/systemTab.ts
+++ b/src/views/jobManager/editJob/systemTab.ts
@@ -46,13 +46,13 @@ export default function getSystemTab(options: JDBCOptions) {
           value: `true`,
           description: `True`,
           text: `Commit (true)`,
-          selected: options["auto commit"] === `true`,
+          selected: options["auto commit"] === true,
         },
         {
           value: `false`,
           description: `False`,
           text: `No commit (false)`,
-          selected: options["auto commit"] === `false`,
+          selected: options["auto commit"] === false,
         },
       ],
       `Specifies whether auto-commit mode is the default connection mode for new connections. Note that, in order to use transaction isolation levels other than *NONE when using auto-commit mode, the property "true autocommit" needs to be set to true.`
@@ -90,13 +90,13 @@ export default function getSystemTab(options: JDBCOptions) {
           value: `true`,
           description: `True`,
           text: `true`,
-          selected: options["cursor hold"] === `true`,
+          selected: options["cursor hold"] === true,
         },
         {
           value: `false`,
           description: `False`,
           text: `false`,
-          selected: options["cursor hold"] === `false`,
+          selected: options["cursor hold"] === false,
         },
       ],
       `	Specifies whether to hold the cursor across transactions. If this property is set to "true", cursors are not closed when a transaction is committed. All resources acquired during the unit of work are held, but locks on specific rows and objects implicitly acquired during the unit of work are released.`
@@ -353,13 +353,13 @@ export default function getSystemTab(options: JDBCOptions) {
           value: `false`,
           text: `Do not use true autocommit`,
           description: `false`,
-          selected: options["true autocommit"] === `false`,
+          selected: options["true autocommit"] === false,
         },
         {
           value: `true`,
           text: `Use true autocommit`,
           description: `true`,
-          selected: options["true autocommit"] === `true`,
+          selected: options["true autocommit"] === true,
         },
       ],
       `Specifies whether the connection should use true auto commit support. True autocommit means that autocommit is on and is running under a isolation level other than *NONE. By default, the driver handles autocommit by running under the system isolation level of *NONE.`


### PR DESCRIPTION
Uses `boolean` type over string type `"true"|"false"` for JDBC options. Also updated UI to respect true/false values as boolean types.