### PR TITLE
Remove server component check after first

### DIFF
--- a/src/connection/serverComponent.ts
+++ b/src/connection/serverComponent.ts
@@ -16,8 +16,8 @@ const octokit = new Octokit();
 const ExecutablePathDir = `$HOME/.vscode/`;
 
 export class ServerComponent {
+  private static installed: boolean = false;
   static outputChannel: OutputChannel;
-  static installed: boolean = false;
 
   static initOutputChannel() {
     if (!this.outputChannel) {
@@ -31,6 +31,10 @@ export class ServerComponent {
     if (this.outputChannel) {
       this.outputChannel.appendLine(jsonString);
     }
+  }
+
+  static isInstalled() {
+    return this.installed;
   }
 
   static getInitCommand(): string|undefined {

--- a/src/testing/jobs.ts
+++ b/src/testing/jobs.ts
@@ -18,7 +18,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Backend version check`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -33,7 +33,7 @@ export const JobsSuite: TestSuite = {
     }},
     
     {name: `Backend set trace options and retrieve`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -49,7 +49,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Backend retrieve trace data without turning on trace`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob();
       await newJob.connect();
@@ -59,7 +59,7 @@ export const JobsSuite: TestSuite = {
     }},
     
     {name: `Paging query`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob({libraries: [`QIWS`], naming: `system`});
       await newJob.connect();
@@ -84,7 +84,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `CL Command (success)`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -104,7 +104,7 @@ export const JobsSuite: TestSuite = {
       newJob.close();
     }},
     {name: `CL Command (error)`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob();
       await newJob.connect();
@@ -125,7 +125,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Retrieve job log`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob();
       await newJob.connect();
@@ -148,7 +148,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Creating a job`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       const newJob = new SQLJob();
 
@@ -194,7 +194,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Library list is used`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob({libraries: [`QSYS`, `SYSTOOLS`], naming: `system`});
       await newJob.connect();
@@ -218,7 +218,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Binding parameters`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       let newJob = new SQLJob({libraries: [`QIWS`], naming: `system`});
       await newJob.connect();
@@ -234,7 +234,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Ensure API compatability`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       const instance = getInstance();
       const content = instance.getContent();
@@ -252,7 +252,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Performance measuring`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
       
       const instance = getInstance();
       const content = instance.getContent();

--- a/src/testing/jobs.ts
+++ b/src/testing/jobs.ts
@@ -18,7 +18,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Backend version check`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -33,7 +33,7 @@ export const JobsSuite: TestSuite = {
     }},
     
     {name: `Backend set trace options and retrieve`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -49,7 +49,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Backend retrieve trace data without turning on trace`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
+
       let newJob = new SQLJob();
       await newJob.connect();
       let trace = await newJob.getTraceData();
@@ -58,6 +59,8 @@ export const JobsSuite: TestSuite = {
     }},
     
     {name: `Paging query`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       let newJob = new SQLJob({libraries: [`QIWS`], naming: `system`});
       await newJob.connect();
 
@@ -81,7 +84,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `CL Command (success)`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
   
       let newJob = new SQLJob();
       await newJob.connect();
@@ -101,7 +104,7 @@ export const JobsSuite: TestSuite = {
       newJob.close();
     }},
     {name: `CL Command (error)`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
 
       let newJob = new SQLJob();
       await newJob.connect();
@@ -122,7 +125,7 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Retrieve job log`, test: async () => {
-      const backendInstalled = await ServerComponent.initialise(false);
+      assert.strictEqual(ServerComponent.installed, true);
 
       let newJob = new SQLJob();
       await newJob.connect();
@@ -145,6 +148,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Creating a job`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       const newJob = new SQLJob();
 
       assert.strictEqual(newJob.getStatus(), JobStatus.NotStarted);
@@ -189,6 +194,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Library list is used`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       let newJob = new SQLJob({libraries: [`QSYS`, `SYSTOOLS`], naming: `system`});
       await newJob.connect();
 
@@ -211,6 +218,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Binding parameters`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       let newJob = new SQLJob({libraries: [`QIWS`], naming: `system`});
       await newJob.connect();
 
@@ -225,6 +234,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Ensure API compatability`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       const instance = getInstance();
       const content = instance.getContent();
 
@@ -241,6 +252,8 @@ export const JobsSuite: TestSuite = {
     }},
 
     {name: `Performance measuring`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+      
       const instance = getInstance();
       const content = instance.getContent();
 

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -16,7 +16,7 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `Adding a job`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       // Ensure we have a blank manager first
       await JobManager.endAll();
@@ -46,7 +46,7 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `End all jobs`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       // Ensure we have a blank manager first
       await JobManager.endAll();
@@ -67,7 +67,7 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `runSQL method`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
 
       // Ensure we have a blank manager first
       await JobManager.endAll();
@@ -97,7 +97,7 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `Set selected by name`, test: async () => {
-      assert.strictEqual(ServerComponent.installed, true);
+      assert.strictEqual(ServerComponent.isInstalled(), true);
       
       // Ensure we have a blank manager first
       await JobManager.endAll();

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -16,6 +16,8 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `Adding a job`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       // Ensure we have a blank manager first
       await JobManager.endAll();
       assert.strictEqual(JobManager.getRunningJobs().length, 0);
@@ -44,6 +46,8 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `End all jobs`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       // Ensure we have a blank manager first
       await JobManager.endAll();
       assert.strictEqual(JobManager.getRunningJobs().length, 0);
@@ -63,6 +67,8 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `runSQL method`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+
       // Ensure we have a blank manager first
       await JobManager.endAll();
       assert.strictEqual(JobManager.getRunningJobs().length, 0);
@@ -91,6 +97,8 @@ export const ManagerSuite: TestSuite = {
     }},
 
     {name: `Set selected by name`, test: async () => {
+      assert.strictEqual(ServerComponent.installed, true);
+      
       // Ensure we have a blank manager first
       await JobManager.endAll();
       assert.strictEqual(JobManager.getRunningJobs().length, 0);


### PR DESCRIPTION
I noticed the tests were running slow and it's because we're checking if the server component is installed on every single test.

We only need to check if it's installed in the first test case, then we check the local property after that.