### PR TITLE
Change "Job ID" to "Job Name" in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
       },
       {
         "command": "vscode-db2i.jobManager.copyJobId",
-        "title": "Copy Job ID",
+        "title": "Copy Job Name",
         "category": "Db2 for i",
         "icon": "$(keyboard)"
       },


### PR DESCRIPTION
Changes "Copy Job ID" to "Copy Job Name" to follow the standard of using "name".