### PR TITLE
bugfix: "Statement has already been fully run"

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -67,11 +67,11 @@ export function generateScroller(basicSelect: string, isCL: boolean): string {
             window.addEventListener('message', event => {
               const scroller = document.getElementById("scroller");
               const data = event.data;
+              myQueryId = data.queryId;
 
               switch (data.command) {
                 case 'rows':
                   isFetching = false;
-                  myQueryId = data.queryId;
                   noMoreRows = data.isDone;
 
                   if (data.rows.length > 0 && scroller.columnDefinitions.length === 0) {

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -102,7 +102,8 @@ class ResultSetPanelProvider {
     this._view.webview.html = html.generateScroller(basicSelect, isCL);
 
     this._view.webview.postMessage({
-      command: `fetch`
+      command: `fetch`,
+      queryId: ``
     });
   }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -56,7 +56,7 @@ class ResultSetPanelProvider {
           this._view.webview.postMessage({
             command: `rows`,
             rows: [],
-            queryId: queryObject.getId(),
+            queryId: ``,
             isDone: true
           });
         }


### PR DESCRIPTION

Running the same statement multiple times resulted in an error saying "Statement has already been run" or "Statement has already been fully run."
Root cause is that we're reusing the web view to post result sets. We may want to revisit that core design decision in the future, but for now, we can simply reset the query object used in the view. 