### PR TITLE
Status Bar item with commitment controls

### DIFF
--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -11,6 +11,12 @@ export enum JobStatus {
   Active = "active",
   Ended = "ended"
 }
+
+export enum TransactionEndType {
+  COMMIT,
+  ROLLBACK
+}
+
 interface ReqRespFmt {
   id: string
 };
@@ -189,11 +195,26 @@ export class SQLJob {
     return this.query<JobLogEntry>(`select * from table(qsys2.joblog_info('*')) a`).run();
   }
 
+  underCommitControl() {
+    return this.options["transaction isolation"] !== `none`;
+  }
+
   async getPendingTransactions() {
     const rows = await this.query<{THECOUNT: number}>(TransactionCountQuery).run(1);
 
     if (rows.success && rows.data && rows.data.length === 1 && rows.data[0].THECOUNT) return rows.data[0].THECOUNT;
     return 0;
+  }
+
+  async endTransaction(type: TransactionEndType) {
+    let query;
+    switch (type) {
+      case TransactionEndType.COMMIT: query = `COMMIT`; break;
+      case TransactionEndType.ROLLBACK: query = `ROLLBACK`; break;
+      default: throw new Error(`TransactionEndType ${type} not valid`);
+    }
+
+    return this.query<JobLogEntry>(query).run();
   }
   
   async close() {

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -4,6 +4,7 @@ import { Config, JobManager } from "../../config";
 import { JobInfo } from "../../connection/manager";
 import { editJobUi } from "./editJob";
 import { displayJobLog } from "./jobLog";
+import { updateStatusBar } from "./statusBar";
 
 const selectJobCommand = `vscode-db2i.jobManager.selectJob`;
 const activeColor = new vscode.ThemeColor(`minimapGutter.addedBackground`);
@@ -116,6 +117,7 @@ export class JobManagerView implements TreeDataProvider<any> {
 
   refresh() {
     this._onDidChangeTreeData.fire();
+    updateStatusBar();
   }
 
   getTreeItem(element: vscode.TreeItem) {

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -11,25 +11,27 @@ export async function updateStatusBar() {
   if (ServerComponent.isInstalled()) {
     const selected = JobManager.getSelection();
 
+    let backgroundColour: ThemeColor|undefined = undefined;
     let toolTipItems = [];
 
     if (selected) {
       item.text = `$(database) ${selected.name}`;
 
-      if (selected.job.options["transaction isolation"] !== `none`) {
+      if (selected.job.underCommitControl()) {
         const pendingsTracts = await selected.job.getPendingTransactions();
         if (pendingsTracts > 0) {
-          item.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
+          backgroundColour = new ThemeColor('statusBarItem.warningBackground');
           item.text = `$(pencil) ${selected.name}`;
 
-          toolTipItems.push(`${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}. [Commit](command:do-commit)`);
-        } else {
-          item.backgroundColor = undefined;
+          toolTipItems.push(
+            `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}.`,
+            `[$(save) Commit](command:vscode-db2i.jobManager.jobCommit) / [$(discard) Revert](command:vscode-db2i.jobManager.jobRollback)`
+          );
         }
       }
 
-      toolTipItems.push(`[View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
-      toolTipItems.push(`[Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
+      toolTipItems.push(`[$(info) View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
+      toolTipItems.push(`[$(edit) Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
     } else {
       item.text = `$(database) No job active`;
       toolTipItems.push(`[Start Job](command:vscode-db2i.jobManager.newJob)`);
@@ -39,6 +41,7 @@ export async function updateStatusBar() {
     toolTip.isTrusted = true;
     
     item.tooltip = toolTip;
+    item.backgroundColor = backgroundColour;
 
     item.show();
   } else {

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -11,17 +11,18 @@ export async function updateStatusBar() {
   if (ServerComponent.isInstalled()) {
     const selected = JobManager.getSelection();
 
+    let text;
     let backgroundColour: ThemeColor|undefined = undefined;
     let toolTipItems = [];
 
     if (selected) {
-      item.text = `$(database) ${selected.name}`;
+      text = `$(database) ${selected.name}`;
 
       if (selected.job.underCommitControl()) {
         const pendingsTracts = await selected.job.getPendingTransactions();
         if (pendingsTracts > 0) {
           backgroundColour = new ThemeColor('statusBarItem.warningBackground');
-          item.text = `$(pencil) ${selected.name}`;
+          text = `$(pencil) ${selected.name}`;
 
           toolTipItems.push(
             `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}.`,
@@ -33,13 +34,14 @@ export async function updateStatusBar() {
       toolTipItems.push(`[$(info) View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
       toolTipItems.push(`[$(edit) Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
     } else {
-      item.text = `$(database) No job active`;
+      text = `$(database) No job active`;
       toolTipItems.push(`[Start Job](command:vscode-db2i.jobManager.newJob)`);
     }
     
     const toolTip = new MarkdownString(toolTipItems.join(`\n\n---\n\n`), true);
     toolTip.isTrusted = true;
     
+    item.text = text;
     item.tooltip = toolTip;
     item.backgroundColor = backgroundColour;
 

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -1,0 +1,33 @@
+import { StatusBarAlignment, ThemeColor, window } from "vscode";
+import { ServerComponent } from "../../connection/serverComponent";
+import { SQLJobManager } from "../../connection/manager";
+import { JobManager } from "../../config";
+
+const item = window.createStatusBarItem(`sqlJob`, StatusBarAlignment.Right);
+
+export async function updateStatusBar() {
+  if (ServerComponent.isInstalled()) {
+    const selected = JobManager.getSelection();
+    if (selected) {
+      item.tooltip = `Active SQL job`;
+      item.text = `$(database) ${selected.name}`;
+
+      if (selected.job.options["transaction isolation"] !== `none`) {
+        const pendingsTracts = await selected.job.getPendingTransactions();
+        if (pendingsTracts > 0) {
+          item.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
+          item.tooltip = `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}`;
+          item.text = `$(pencil) ${selected.name}`;
+        } else {
+          item.backgroundColor = undefined;
+        }
+      }
+    } else {
+      item.text = `$(database) No job active`;
+    }
+
+    item.show();
+  } else {
+    item.hide();
+  }
+}

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -1,30 +1,44 @@
-import { StatusBarAlignment, ThemeColor, window } from "vscode";
+import { MarkdownString, StatusBarAlignment, ThemeColor, languages, window } from "vscode";
 import { ServerComponent } from "../../connection/serverComponent";
 import { SQLJobManager } from "../../connection/manager";
 import { JobManager } from "../../config";
+
+const statusItem = languages.createLanguageStatusItem(`sqlStatus`, {language: `sql`});
 
 const item = window.createStatusBarItem(`sqlJob`, StatusBarAlignment.Right);
 
 export async function updateStatusBar() {
   if (ServerComponent.isInstalled()) {
     const selected = JobManager.getSelection();
+
+    let toolTipItems = [];
+
     if (selected) {
-      item.tooltip = `Active SQL job`;
       item.text = `$(database) ${selected.name}`;
 
       if (selected.job.options["transaction isolation"] !== `none`) {
         const pendingsTracts = await selected.job.getPendingTransactions();
         if (pendingsTracts > 0) {
           item.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
-          item.tooltip = `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}`;
           item.text = `$(pencil) ${selected.name}`;
+
+          toolTipItems.push(`${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}. [Commit](command:do-commit)`);
         } else {
           item.backgroundColor = undefined;
         }
       }
+
+      toolTipItems.push(`[View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
+      toolTipItems.push(`[Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
     } else {
       item.text = `$(database) No job active`;
+      toolTipItems.push(`[Start Job](command:vscode-db2i.jobManager.newJob)`);
     }
+    
+    const toolTip = new MarkdownString(toolTipItems.join(`\n\n---\n\n`), true);
+    toolTip.isTrusted = true;
+    
+    item.tooltip = toolTip;
 
     item.show();
   } else {

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -26,7 +26,7 @@ export async function updateStatusBar() {
 
           toolTipItems.push(
             `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}.`,
-            `[$(save) Commit](command:vscode-db2i.jobManager.jobCommit) / [$(discard) Revert](command:vscode-db2i.jobManager.jobRollback)`
+            `[$(save) Commit](command:vscode-db2i.jobManager.jobCommit) / [$(discard) Rollback](command:vscode-db2i.jobManager.jobRollback)`
           );
         }
       }

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -5,7 +5,7 @@ import { JobManager } from "../../config";
 
 const statusItem = languages.createLanguageStatusItem(`sqlStatus`, {language: `sql`});
 
-const item = window.createStatusBarItem(`sqlJob`, StatusBarAlignment.Right);
+const item = window.createStatusBarItem(`sqlJob`, StatusBarAlignment.Left);
 
 export async function updateStatusBar() {
   if (ServerComponent.isInstalled()) {

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -25,7 +25,7 @@ export async function updateStatusBar() {
           text = `$(pencil) ${selected.name}`;
 
           toolTipItems.push(
-            `${pendingsTracts} pending change${pendingsTracts !== 1 ? `s` : ``}.`,
+            `$(warning) Pending Transaction`,
             `[$(save) Commit](command:vscode-db2i.jobManager.jobCommit) / [$(discard) Rollback](command:vscode-db2i.jobManager.jobRollback)`
           );
         }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -7,6 +7,7 @@ import * as html from "./html";
 import { getInstance } from "../../base";
 import { JobManager } from "../../config";
 import { Query, QueryState } from "../../connection/query";
+import { updateStatusBar } from "../jobManager/statusBar";
 
 function delay(t: number, v?: number) {
   return new Promise(resolve => setTimeout(resolve, t, v));
@@ -60,6 +61,8 @@ class ResultSetPanelProvider {
             isDone: true
           });
         }
+
+        updateStatusBar();
       }
     });
   }


### PR DESCRIPTION
A new status bar item has been added that will:

* Have quick access to the job log and connection settings view
* Changes colour if there are pending uncommitted changes when using commitment control
* Shows how many many changes along with commit and rollback buttons.
* Stops jobs from ended when there are pending changes remaining without deciding what to do with them.

<img width="511" alt="image" src="https://github.com/halcyon-tech/vscode-db2i/assets/3708366/2283d1b3-5089-447b-be8b-82ed06716c17">


To test:

* Change isolation level from none
* Set auto commit to false