### PR TITLE
Feature/cursor_autoclose

### DIFF
--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -94,7 +94,10 @@ export class SQLJobManager {
       // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
       // int. This is the largest number available without overflow (Integer.MAX_VALUE)
       const rowsToFetch = 2147483647;
-      const results = await selected.job.query<T>(query, {parameters}).run(rowsToFetch);
+      const cursor =  selected.job.query<T>(query, {parameters});
+      const results = await cursor.run(rowsToFetch);
+      cursor.close();
+      
       return results.data;
     } else {
       const instance = getInstance();

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -94,10 +94,9 @@ export class SQLJobManager {
       // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
       // int. This is the largest number available without overflow (Integer.MAX_VALUE)
       const rowsToFetch = 2147483647;
-      const cursor =  selected.job.query<T>(query, {parameters});
-      const results = await cursor.run(rowsToFetch);
-      cursor.close();
-      
+
+      // No close here required because it's not a prepared statement (no parameters)
+      const results = await selected.job.query<T>(query, {parameters}).run(rowsToFetch);
       return results.data;
     } else {
       const instance = getInstance();

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -95,8 +95,9 @@ export class SQLJobManager {
       // int. This is the largest number available without overflow (Integer.MAX_VALUE)
       const rowsToFetch = 2147483647;
 
-      // No close here required because it's not a prepared statement (no parameters)
-      const results = await selected.job.query<T>(query, {parameters}).run(rowsToFetch);
+      const statement = selected.job.query<T>(query, {parameters});
+      const results = await statement.run(rowsToFetch);
+      statement.close();
       return results.data;
     } else {
       const instance = getInstance();

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -17,7 +17,7 @@ export class Query<T> {
   private isCLCommand: boolean;
   private state: QueryState = QueryState.NOT_YET_RUN;
 
-  public shouldAutoClose: boolean | undefined;
+  public shouldAutoClose: boolean;
 
   constructor(private job: SQLJob, query: string, opts: QueryOptions = { isClCommand: false, parameters: undefined, autoClose: false }) {
     this.job = job;

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -124,7 +124,6 @@ export class Query<T> {
   }
 
   public async close() {
-    // TODO: close the cursor
     this.state = QueryState.RUN_DONE;
 
     if (this.correlationId) {

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -17,7 +17,7 @@ export class Query<T> {
   private isCLCommand: boolean;
   private state: QueryState = QueryState.NOT_YET_RUN;
 
-  public autoClose: boolean | undefined;
+  public shouldAutoClose: boolean | undefined;
 
   constructor(private job: SQLJob, query: string, opts: QueryOptions = { isClCommand: false, parameters: undefined, autoClose: false }) {
     this.job = job;
@@ -25,7 +25,7 @@ export class Query<T> {
     this.parameters = opts.parameters;
     this.sql = query;
     this.isCLCommand = opts.isClCommand;
-    this.autoClose = opts.autoClose;
+    this.shouldAutoClose = opts.autoClose;
 
     Query.globalQueryList.push(this);
   }
@@ -46,7 +46,7 @@ export class Query<T> {
     // First, let's check to see if we should also cleanup
     // any cursors that remain open, and we've been told to close
     for (const query of this.globalQueryList) {
-      if (query.autoClose) {
+      if (query.shouldAutoClose) {
         closePromises.push(query.close())
       }
     };

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -124,9 +124,8 @@ export class Query<T> {
   }
 
   public async close() {
-    this.state = QueryState.RUN_DONE;
-
-    if (this.correlationId) {
+    if (this.correlationId && this.state !== QueryState.RUN_DONE) {
+      this.state = QueryState.RUN_DONE;
       let queryObject = {
         id: SQLJob.getNewUniqueRequestId(`sqlclose`),
         cont_id: this.correlationId,

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -12,14 +12,14 @@ export class Query<T> {
   private correlationId: string;
   private sql: string;
   private isPrepared: boolean = false;
-  private parameters: any[];
+  private parameters: any[]|undefined;
   private rowsToFetch: number = 100;
   private isCLCommand: boolean;
   private state: QueryState = QueryState.NOT_YET_RUN;
 
   public autoClose: boolean | undefined;
 
-  constructor(private job: SQLJob, query: string, opts: QueryOptions = { isClCommand: false, parameters: [], autoClose: false }) {
+  constructor(private job: SQLJob, query: string, opts: QueryOptions = { isClCommand: false, parameters: undefined, autoClose: false }) {
     this.job = job;
     this.isPrepared = (undefined !== opts.parameters);
     this.parameters = opts.parameters;
@@ -126,7 +126,7 @@ export class Query<T> {
   public async close() {
     this.state = QueryState.RUN_DONE;
 
-    if (this.correlationId) {
+    if (this.correlationId && this.isPrepared) {
       let queryObject = {
         id: SQLJob.getNewUniqueRequestId(`sqlclose`),
         cont_id: this.correlationId,

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -126,7 +126,7 @@ export class Query<T> {
   public async close() {
     this.state = QueryState.RUN_DONE;
 
-    if (this.correlationId && this.isPrepared) {
+    if (this.correlationId) {
       let queryObject = {
         id: SQLJob.getNewUniqueRequestId(`sqlclose`),
         cont_id: this.correlationId,

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -34,6 +34,12 @@ export class Query<T> {
     return (undefined === id || '' === id) ? undefined : Query.globalQueryList.find(query => query.correlationId === id);
   }
 
+  public static getOpenIds(forJob?: string) {
+    return this.globalQueryList
+      .filter(q => q.job.id === forJob || forJob === undefined)
+      .map(q => q.correlationId);
+  }
+
   public static async cleanup() {
     let closePromises = [];
 
@@ -121,13 +127,15 @@ export class Query<T> {
     // TODO: close the cursor
     this.state = QueryState.RUN_DONE;
 
-    let queryObject = {
-      id: SQLJob.getNewUniqueRequestId(`sqlclose`),
-      cont_id: this.correlationId,
-      type: `sqlclose`,
-    };
+    if (this.correlationId) {
+      let queryObject = {
+        id: SQLJob.getNewUniqueRequestId(`sqlclose`),
+        cont_id: this.correlationId,
+        type: `sqlclose`,
+      };
 
-    return this.job.send(JSON.stringify(queryObject));
+      return this.job.send(JSON.stringify(queryObject));
+    }
   }
 
   public getId(): string {

--- a/src/connection/query.ts
+++ b/src/connection/query.ts
@@ -17,23 +17,46 @@ export class Query<T> {
   private isCLCommand: boolean;
   private state: QueryState = QueryState.NOT_YET_RUN;
 
-  constructor(private job: SQLJob, query: string, opts: QueryOptions = {isClCommand: false, parameters: undefined}) {
+  public autoClose: boolean | undefined;
+
+  constructor(private job: SQLJob, query: string, opts: QueryOptions = { isClCommand: false, parameters: [], autoClose: false }) {
     this.job = job;
     this.isPrepared = (undefined !== opts.parameters);
     this.parameters = opts.parameters;
     this.sql = query;
     this.isCLCommand = opts.isClCommand;
+    this.autoClose = opts.autoClose;
+
     Query.globalQueryList.push(this);
   }
+
   public static byId(id: string) {
     return (undefined === id || '' === id) ? undefined : Query.globalQueryList.find(query => query.correlationId === id);
   }
+
+  public static async cleanup() {
+    let closePromises = [];
+
+    // First, let's check to see if we should also cleanup
+    // any cursors that remain open, and we've been told to close
+    for (const query of this.globalQueryList) {
+      if (query.autoClose) {
+        closePromises.push(query.close())
+      }
+    };
+
+    await Promise.all(closePromises);
+
+    // Automatically remove any queries done and dusted. They're useless.
+    this.globalQueryList = this.globalQueryList.filter(q => q.getState() !== QueryState.RUN_DONE);
+  }
+
   public async run(rowsToFetch: number = this.rowsToFetch): Promise<QueryResult<T>> {
     switch (this.state) {
-    case QueryState.RUN_MORE_DATA_AVAILABLE:
-      throw new Error('Statement has already been run');
-    case QueryState.RUN_DONE:
-      throw new Error('Statement has already been fully run');
+      case QueryState.RUN_MORE_DATA_AVAILABLE:
+        throw new Error('Statement has already been run');
+      case QueryState.RUN_DONE:
+        throw new Error('Statement has already been fully run');
     }
     let queryObject;
     if (this.isCLCommand) {
@@ -55,7 +78,7 @@ export class Query<T> {
     let result = await this.job.send(JSON.stringify(queryObject));
     let queryResult: QueryResult<T> = JSON.parse(result);
 
-    this.state = queryResult.is_done? QueryState.RUN_DONE: QueryState.RUN_MORE_DATA_AVAILABLE;
+    this.state = queryResult.is_done ? QueryState.RUN_DONE : QueryState.RUN_MORE_DATA_AVAILABLE;
 
     if (queryResult.success !== true && !this.isCLCommand) {
       this.state = QueryState.ERROR;
@@ -64,13 +87,14 @@ export class Query<T> {
     this.correlationId = queryResult.id;
     return queryResult;
   }
+
   public async fetchMore(rowsToFetch: number = this.rowsToFetch): Promise<QueryResult<T>> {
     //TODO: verify that the SQL job hasn't changed
     switch (this.state) {
-    case QueryState.NOT_YET_RUN:
-      throw new Error('Statement has not yet been run');
-    case QueryState.RUN_DONE:
-      throw new Error('Statement has already been fully run');
+      case QueryState.NOT_YET_RUN:
+        throw new Error('Statement has not yet been run');
+      case QueryState.RUN_DONE:
+        throw new Error('Statement has already been fully run');
     }
     let queryObject = {
       id: SQLJob.getNewUniqueRequestId(`fetchMore`),
@@ -84,7 +108,7 @@ export class Query<T> {
     let result = await this.job.send(JSON.stringify(queryObject));
 
     let queryResult: QueryResult<T> = JSON.parse(result);
-    this.state = queryResult.is_done? QueryState.RUN_DONE: QueryState.RUN_MORE_DATA_AVAILABLE;
+    this.state = queryResult.is_done ? QueryState.RUN_DONE : QueryState.RUN_MORE_DATA_AVAILABLE;
 
     if (queryResult.success !== true) {
       this.state = QueryState.ERROR;
@@ -92,12 +116,24 @@ export class Query<T> {
     }
     return queryResult;
   }
+
   public async close() {
+    // TODO: close the cursor
     this.state = QueryState.RUN_DONE;
+
+    let queryObject = {
+      id: SQLJob.getNewUniqueRequestId(`sqlclose`),
+      cont_id: this.correlationId,
+      type: `sqlclose`,
+    };
+
+    return this.job.send(JSON.stringify(queryObject));
   }
+
   public getId(): string {
     return this.correlationId;
   }
+
   public getState(): QueryState {
     return this.state;
   }

--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -30,7 +30,8 @@ export enum ServerTraceDest {
 }
 export interface QueryOptions {
   isClCommand?: boolean,
-  parameters?: any[]
+  parameters?: any[],
+  autoClose?: boolean
 }
 export interface SetConfigResult extends ServerResponse {
   tracedest: ServerTraceDest,

--- a/src/testing/jobs.ts
+++ b/src/testing/jobs.ts
@@ -4,6 +4,7 @@ import { JobStatus, SQLJob } from "../connection/sqlJob";
 import { getInstance } from "../base";
 import { ServerComponent } from "../connection/serverComponent";
 import { ServerTraceDest, ServerTraceLevel } from "../connection/types";
+import { Query } from "../connection/query";
 
 export const JobsSuite: TestSuite = {
   name: `Connection tests`,
@@ -83,6 +84,35 @@ export const JobsSuite: TestSuite = {
       newJob.close();
     }},
 
+    {name: `Auto close statements`, test: async () => {
+      let newJob = new SQLJob();
+      await newJob.connect();
+
+      const autoCloseAnyway = newJob.query(`select * from QIWS.QCUSTCDT`, {autoClose: true});
+      const noAutoClose = newJob.query(`select * from QIWS.QCUSTCDT`, {autoClose: false});
+      const neverRuns = newJob.query(`select * from QIWS.QCUSTCDT`, {autoClose: true});
+
+      assert.strictEqual(Query.getOpenIds(newJob.id).length, 3);
+
+      // If we ran this, two both autoClose statements would be cleaned up
+      // await Query.cleanup();
+
+      await Promise.all([autoCloseAnyway.run(1), noAutoClose.run(1)]);
+
+      assert.strictEqual(Query.getOpenIds(newJob.id).length, 3);
+      
+      // Now cleanup should auto close autoCloseAnyway and neverRuns,
+      // but not noAutoClose because it hasn't finished running
+      await Query.cleanup();
+
+      const leftOverIds = Query.getOpenIds(newJob.id);
+      assert.strictEqual(leftOverIds.length, 1);
+
+      assert.strictEqual(noAutoClose.getId(), leftOverIds[0]);
+
+      newJob.close();
+    }},
+
     {name: `CL Command (success)`, test: async () => {
       assert.strictEqual(ServerComponent.isInstalled(), true);
   
@@ -103,6 +133,7 @@ export const JobsSuite: TestSuite = {
       assert.equal(CPF2880, true);
       newJob.close();
     }},
+
     {name: `CL Command (error)`, test: async () => {
       assert.strictEqual(ServerComponent.isInstalled(), true);
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -38,6 +38,7 @@ class ResultSetPanelProvider {
         let queryObject = Query.byId(message.queryId);
         try {
           if (queryObject === undefined) {
+            // We will need to revisit this if we ever allow multiple result tabs like ACS does
             Query.cleanup();
 
             let query = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL, autoClose: true });

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -33,17 +33,17 @@ class ResultSetPanelProvider {
     webviewView.webview.html = html.getLoadingHTML();
     this._view.webview.onDidReceiveMessage(async (message) => {
       if (message.query) {
-        const instance = await getInstance();
-        const content = instance.getContent();
-        const config = instance.getConfig();
         let data = [];
 
         let queryObject = Query.byId(message.queryId);
         try {
-          if (undefined === queryObject) {
-            let query = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL });
+          if (queryObject === undefined) {
+            Query.cleanup();
+
+            let query = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL, autoClose: true });
             queryObject = query;
           }
+
           let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();
           data = queryResults.data;
           this._view.webview.postMessage({


### PR DESCRIPTION
This PR implements a cleanup process that is used so the user can swiftly run new statements with cursors and the backend correctly closes them as they run new ones.

This is implemented with a system that automatically closes flagged statements with `autoClose`, which should typically be used on user run statements. A test case has been written to prove that it does cleanup cursors.

We now automatically close the cursor when:

* Running statements through `JobManager.runSQL` (manually using `close`)
* Running paging queries in the results view (using the new `autoClose` method)