### PR TITLE
Add ALTER support to tokeniser (#77)

### DIFF
--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -107,6 +107,25 @@ export default class Statement {
 				// CALL X()
 				doAdd(this.getRefAtToken(1));
 				break;
+
+			case StatementType.Alter:
+				if (this.tokens.length >= 3) {
+					let object = this.getRefAtToken(2);
+
+					if (object) {
+						object.type = this.tokens[1].value;
+
+						doAdd(object);
+
+						for (let i = object.tokens.length+2; i < this.tokens.length; i++) {
+							if (tokenIs(this.tokens[i], `keyword`, `REFERENCES`)) {
+								doAdd(this.getRefAtToken(i+1));
+							}
+						}
+					}
+				}
+				break;
+
 			case StatementType.Insert:
 			case StatementType.Select:
 			case StatementType.Delete:

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -433,6 +433,64 @@ describe(`Object references`, () => {
     expect(refsA[0].object.name).toBe(`create_Sql_sample`);
     expect(refsA[0].object.schema).toBe(`"QSYS"`);
   });
+
+  test(`ALTER: with reference`, () => {
+    const content = [
+      `ALTER TABLE DEPARTMENT`,
+      `      ADD FOREIGN KEY RDE (MGRNO)`,
+      `          REFERENCES EMPLOYEE`,
+      `          ON DELETE SET NULL;`,
+    ].join(`\n`);
+
+    const document = new Document(content);
+
+    expect(document.statements.length).toBe(1);
+  
+    const statement = document.statements[0];
+    
+    expect(statement.type).toBe(StatementType.Alter);
+
+    const objs = statement.getObjectReferences();
+
+    expect(objs.length).toBe(2);
+
+    expect(objs[0].tokens.length).toBe(1);
+    expect(objs[0].object.name).toBe(`DEPARTMENT`);
+    expect(objs[0].object.schema).toBeUndefined();
+
+    expect(objs[1].tokens.length).toBe(1);
+    expect(objs[1].object.name).toBe(`EMPLOYEE`);
+    expect(objs[1].object.schema).toBeUndefined();
+  });
+
+  test(`ALTER: with qualified reference`, () => {
+    const content = [
+      `ALTER TABLE myschema.dept`,
+      `      ADD FOREIGN KEY RDE (MGRNO)`,
+      `          REFERENCES myschema.emp`,
+      `          ON DELETE SET NULL;`,
+    ].join(`\n`);
+
+    const document = new Document(content);
+
+    expect(document.statements.length).toBe(1);
+  
+    const statement = document.statements[0];
+
+    expect(statement.type).toBe(StatementType.Alter);
+
+    const objs = statement.getObjectReferences();
+
+    expect(objs.length).toBe(2);
+
+    expect(objs[0].tokens.length).toBe(3);
+    expect(objs[0].object.name).toBe(`dept`);
+    expect(objs[0].object.schema).toBe(`myschema`);
+
+    expect(objs[1].tokens.length).toBe(3);
+    expect(objs[1].object.name).toBe(`emp`);
+    expect(objs[1].object.schema).toBe(`myschema`);
+  });
 });
 
 describe(`Offset reference tests`, () => {

--- a/src/language/sql/tokens.ts
+++ b/src/language/sql/tokens.ts
@@ -23,7 +23,7 @@ export default class SQLTokeniser {
     {
       name: `STATEMENTTYPE`,
       match: [{ type: `word`, match: (value: string) => {
-        return [`CREATE`, `SELECT`, `WITH`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CALL`, `DECLARE`].includes(value.toUpperCase());
+        return [`CREATE`, `ALTER`, `SELECT`, `WITH`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CALL`, `DECLARE`].includes(value.toUpperCase());
       } }],
       becomes: `statementType`,
     },
@@ -56,7 +56,7 @@ export default class SQLTokeniser {
     {
       name: `KEYWORD`,
       match: [{ type: `word`, match: (value: string) => {
-        return [`AS`, `OR`, `REPLACE`, `FROM`, `INTO`, `BEGIN`, `END`, `CURSOR`, `DEFAULT`, `HANDLER`].includes(value.toUpperCase());
+        return [`AS`, `OR`, `REPLACE`, `FROM`, `INTO`, `BEGIN`, `END`, `CURSOR`, `DEFAULT`, `HANDLER`, `REFERENCES`].includes(value.toUpperCase());
       } }],
       becomes: `keyword`,
     },

--- a/src/language/sql/types.ts
+++ b/src/language/sql/types.ts
@@ -11,7 +11,8 @@ export enum StatementType {
 	Begin = "Begin",
 	Drop = "Drop",
 	End = "End",
-	Call = "Call"
+	Call = "Call",
+	Alter = "Alter"
 }
 
 export const StatementTypeWord = {
@@ -25,7 +26,8 @@ export const StatementTypeWord = {
 	'DROP': StatementType.Drop,
 	'END': StatementType.End,
 	'CALL': StatementType.Call,
-	'BEGIN': StatementType.Begin
+	'BEGIN': StatementType.Begin,
+	'ALTER': StatementType.Alter
 };
 
 export interface IRange {


### PR DESCRIPTION
Fixes #77 by adding support the `ALTER` statement type and object reference support.