### PR TITLE
Fixup building of `.vsix` in CI

### DIFF
--- a/.github/workflows/webpack_ci.yaml
+++ b/.github/workflows/webpack_ci.yaml
@@ -29,11 +29,13 @@ jobs:
         npm install -g vsce
         vsce package
 
-    - name: Copy dist artifacts to staging directory
-      run: mkdir staging && cp ./*.vsix staging
+    - name: get .vsix name
+      run: |
+        echo "vsix_name=$(echo *.vsix)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
 
     - name: Upload dist artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: Package
-        path: staging
+        name: test_vsix
+        path: ${{env.vsix_name}}


### PR DESCRIPTION
Fix an issue that sometimes caused files in the CI-built test package to be created with an incorrect file extension
![image](https://github.com/halcyon-tech/vscode-db2i/assets/17914061/4637d4a6-219f-4d72-8461-eac2b92a20ff)
