### PR TITLE
Validate user-entered schema / Browse to add schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
         "icon": "$(add)"
       },
       {
+        "command": "vscode-db2i.browseForSchemasToAddToSchemaBrowser",
+        "title": "Browse for Schemas to Add to Schema Browser",
+        "category": "Db2 for i",
+        "icon": "$(list-selection)"
+      },
+      {
         "command": "vscode-db2i.removeSchemaFromSchemaBrowser",
         "title": "Remove schema from view",
         "category": "Db2 for i",
@@ -389,6 +395,11 @@
       "view/title": [
         {
           "command": "vscode-db2i.addSchemaToSchemaBrowser",
+          "group": "navigation",
+          "when": "view == schemaBrowser"
+        },
+        {
+          "command": "vscode-db2i.browseForSchemasToAddToSchemaBrowser",
           "group": "navigation",
           "when": "view == schemaBrowser"
         },

--- a/package.json
+++ b/package.json
@@ -157,14 +157,8 @@
         "icon": "$(refresh)"
       },
       {
-        "command": "vscode-db2i.addSchemaToSchemaBrowser",
-        "title": "Add Schema to Schema Browser",
-        "category": "Db2 for i",
-        "icon": "$(add)"
-      },
-      {
-        "command": "vscode-db2i.browseForSchemasToAddToSchemaBrowser",
-        "title": "Browse for Schemas to Add to Schema Browser",
+        "command": "vscode-db2i.manageSchemaBrowserList",
+        "title": "Manage Schema Browser List",
         "category": "Db2 for i",
         "icon": "$(list-selection)"
       },
@@ -394,12 +388,7 @@
       ],
       "view/title": [
         {
-          "command": "vscode-db2i.addSchemaToSchemaBrowser",
-          "group": "navigation",
-          "when": "view == schemaBrowser"
-        },
-        {
-          "command": "vscode-db2i.browseForSchemasToAddToSchemaBrowser",
+          "command": "vscode-db2i.manageSchemaBrowserList",
           "group": "navigation",
           "when": "view == schemaBrowser"
         },

--- a/package.json
+++ b/package.json
@@ -390,7 +390,7 @@
         {
           "command": "vscode-db2i.manageSchemaBrowserList",
           "group": "navigation",
-          "when": "view == schemaBrowser"
+          "when": "view == schemaBrowser && vscode-db2i:manageSchemaBrowserEnabled"
         },
         {
           "command": "vscode-db2i.refreshSchemaBrowser",

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -4,7 +4,7 @@ import { getInstance } from "../base";
 import Statement from "./statement";
 import { JobManager } from "../config";
 
-type SQLType = "tables"|"views"|"aliases"|"constraints"|"functions"|"variables"|"indexes"|"procedures"|"sequences"|"packages"|"triggers"|"types";
+type SQLType = "schemas"|"tables"|"views"|"aliases"|"constraints"|"functions"|"variables"|"indexes"|"procedures"|"sequences"|"packages"|"triggers"|"types";
 type PageData = {filter?: string, offset?: number, limit?: number};
 
 const typeMap = {
@@ -18,101 +18,113 @@ export default class Database {
    * @param schema Not user input
    */
   static async getObjects(schema: string, type: SQLType, details: PageData = {}): Promise<BasicSQLObject[]> {
-    let objects;
-
+    let query : string;
     switch (type) {
+      case `schemas`:
+        query = [
+          `select SCHEMA_NAME as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME `,
+          `from QSYS2.SYSSCHEMAS`,
+          details.filter ? `where SCHEMA_NAME = '${details.filter}' or SYSTEM_SCHEMA_NAME = '${details.filter}'` : ``,
+          `order by SCHEMA_NAME asc`
+        ].join(` `);
+          break;
     case `tables`:
     case `views`:
     case `aliases`:
-      objects = await JobManager.runSQL([
-        `select TABLE_NAME as NAME, TABLE_TEXT as TEXT, BASE_TABLE_SCHEMA as BASE_SCHEMA, BASE_TABLE_NAME as BASE_OBJ, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA from QSYS2.SYSTABLES`,
+      query = [
+        `select TABLE_NAME as NAME, TABLE_TEXT as TEXT, BASE_TABLE_SCHEMA as BASE_SCHEMA, BASE_TABLE_NAME as BASE_OBJ, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSTABLES`,
         `where TABLE_SCHEMA = '${schema}' and TABLE_TYPE in (${typeMap[type].map(item => `'${item}'`).join(`, `)}) ${details.filter ? `and TABLE_NAME like '%${details.filter}%'`: ``}`,
-        `order by TABLE_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by TABLE_NAME asc`
+      ].join(` `);
       break;
 
     case `constraints`:
-      objects = await JobManager.runSQL([
-        `select CONSTRAINT_NAME as NAME, CONSTRAINT_TEXT as TEXT, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA from QSYS2.SYSCST`,
+      query = [
+        `select CONSTRAINT_NAME as NAME, CONSTRAINT_TEXT as TEXT, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSCST`,
         `where CONSTRAINT_SCHEMA = '${schema}' ${details.filter ? `and CONSTRAINT_NAME like '%${details.filter}%'`: ``}`,
-        `order by CONSTRAINT_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by CONSTRAINT_NAME asc`
+      ].join(` `);
       break;
 
     case `functions`:
-      objects = await JobManager.runSQL([
-        `select ROUTINE_NAME as NAME, SPECIFIC_NAME as SPECNAME, coalesce(ROUTINE_TEXT, LONG_COMMENT) as TEXT from QSYS2.SYSFUNCS`,
+      query = [
+        `select ROUTINE_NAME as NAME, SPECIFIC_NAME as SPECNAME, coalesce(ROUTINE_TEXT, LONG_COMMENT) as TEXT `,
+        `from QSYS2.SYSFUNCS`,
         `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and ROUTINE_NAME like '%${details.filter}%'`: ``} and FUNCTION_ORIGIN in ('E','U')`,
-        `order by ROUTINE_NAME asc, SPECIFIC_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by ROUTINE_NAME asc`
+      ].join(` `);
       break;
 
     case `variables`:
-      objects = await JobManager.runSQL([
-        `select VARIABLE_NAME as NAME, VARIABLE_TEXT as TEXT, SYSTEM_VAR_NAME as SYS_NAME, SYSTEM_VAR_SCHEMA as SYS_SCHEMA from QSYS2.SYSVARIABLES`,
+      query = [
+        `select VARIABLE_NAME as NAME, VARIABLE_TEXT as TEXT, SYSTEM_VAR_NAME as SYS_NAME, SYSTEM_VAR_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSVARIABLES`,
         `where VARIABLE_SCHEMA = '${schema}' ${details.filter ? `and VARIABLE_NAME like '%${details.filter}%'`: ``}`,
-        `order by VARIABLE_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by VARIABLE_NAME asc`
+      ].join(` `);
       break;
 
     case `indexes`:
-      objects = await JobManager.runSQL([
-        `select INDEX_NAME as NAME, INDEX_TEXT as TEXT, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ, SYSTEM_INDEX_NAME as SYS_NAME, SYSTEM_INDEX_SCHEMA as SYS_SCHEMA from QSYS2.SYSINDEXES`,
+      query = [
+        `select INDEX_NAME as NAME, INDEX_TEXT as TEXT, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ, SYSTEM_INDEX_NAME as SYS_NAME, SYSTEM_INDEX_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSINDEXES`,
         `where INDEX_SCHEMA = '${schema}' ${details.filter ? `and INDEX_NAME like '%${details.filter}%'`: ``}`,
-        `order by INDEX_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by INDEX_NAME asc`
+      ].join(` `);
       break;
 
     case `procedures`:
-      objects = await JobManager.runSQL([
-        `select ROUTINE_NAME as NAME, SPECIFIC_NAME as SPECNAME, ROUTINE_TEXT as TEXT from QSYS2.SYSPROCS`,
+      query = [
+        `select ROUTINE_NAME as NAME, SPECIFIC_NAME as SPECNAME, ROUTINE_TEXT as TEXT `,
+        `from QSYS2.SYSPROCS`,
         `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and ROUTINE_NAME like '%${details.filter}%'`: ``}`,
-        `order by ROUTINE_NAME asc, SPECIFIC_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by ROUTINE_NAME asc`
+      ].join(` `);
       break;
 
     case `sequences`:
-      objects = await JobManager.runSQL([
-        `select SEQUENCE_NAME as NAME, SEQUENCE_TEXT as TEXT, SYSTEM_SEQ_NAME as SYS_NAME, SYSTEM_SEQ_SCHEMA as SYS_SCHEMA from QSYS2.SYSSEQUENCES`,
+      query = [
+        `select SEQUENCE_NAME as NAME, SEQUENCE_TEXT as TEXT, SYSTEM_SEQ_NAME as SYS_NAME, SYSTEM_SEQ_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSSEQUENCES`,
         `where SEQUENCE_SCHEMA = '${schema}' ${details.filter ? `and SEQUENCE_NAME like '%${details.filter}%'`: ``}`,
-        `order by SEQUENCE_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by SEQUENCE_NAME asc`
+      ].join(` `);
       break;
 
     case `packages`:
-      objects = await JobManager.runSQL([
-        `select PACKAGE_NAME as NAME, PACKAGE_TEXT as TEXT, PROGRAM_SCHEMA as BASE_SCHEMA, PROGRAM_NAME as BASE_OBJ from QSYS2.SQLPACKAGE`,
+      query = [
+        `select PACKAGE_NAME as NAME, PACKAGE_TEXT as TEXT, PROGRAM_SCHEMA as BASE_SCHEMA, PROGRAM_NAME as BASE_OBJ `,
+        `from QSYS2.SQLPACKAGE`,
         `where PACKAGE_SCHEMA = '${schema}' ${details.filter ? `and PACKAGE_NAME like '%${details.filter}%'`: ``}`,
-        `order by PACKAGE_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by PACKAGE_NAME asc`
+      ].join(` `);
       break;
 
     case `triggers`:
-      objects = await JobManager.runSQL([
-        `select TRIGGER_NAME as NAME, TRIGGER_TEXT as TEXT, EVENT_OBJECT_SCHEMA as BASE_SCHEMA, EVENT_OBJECT_TABLE as BASE_OBJ from QSYS2.SYSTRIGGERS`,
+      query = [
+        `select TRIGGER_NAME as NAME, TRIGGER_TEXT as TEXT, EVENT_OBJECT_SCHEMA as BASE_SCHEMA, EVENT_OBJECT_TABLE as BASE_OBJ `,
+        `from QSYS2.SYSTRIGGERS`,
         `where TRIGGER_SCHEMA = '${schema}' ${details.filter ? `and TRIGGER_NAME like '%${details.filter}%'`: ``}`,
-        `order by TRIGGER_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by TRIGGER_NAME asc`
+      ].join(` `);
       break;
 
     case `types`:
-      objects = await JobManager.runSQL([
-        `select USER_DEFINED_TYPE_NAME as NAME, TYPE_TEXT as TEXT, SYSTEM_TYPE_NAME as SYS_NAME, SYSTEM_TYPE_SCHEMA as SYS_SCHEMA from QSYS2.SYSTYPES`,
+      query = [
+        `select USER_DEFINED_TYPE_NAME as NAME, TYPE_TEXT as TEXT, SYSTEM_TYPE_NAME as SYS_NAME, SYSTEM_TYPE_SCHEMA as SYS_SCHEMA `,
+        `from QSYS2.SYSTYPES`,
         `where USER_DEFINED_TYPE_SCHEMA = '${schema}' ${details.filter ? `and USER_DEFINED_TYPE_NAME like '%${details.filter}%'`: ``}`,
-        `order by USER_DEFINED_TYPE_NAME asc`,
-        `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
-      ].join(` `));
+        `order by USER_DEFINED_TYPE_NAME asc`
+      ].join(` `);
       break;
     }
+
+    let objects : any[] = await JobManager.runSQL([
+      query,
+      `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
+    ].join(` `));
 
     return objects.map(object => ({
       type,

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -25,7 +25,7 @@ export default class Database {
           `select SCHEMA_NAME as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME `,
           `from QSYS2.SYSSCHEMAS`,
           details.filter ? `where SCHEMA_NAME = '${details.filter}' or SYSTEM_SCHEMA_NAME = '${details.filter}'` : ``,
-          `order by SCHEMA_NAME asc`
+          `order by QSYS2.DELIMIT_NAME(SCHEMA_NAME) asc`
         ].join(` `);
           break;
     case `tables`:


### PR DESCRIPTION
Ready for review and some testing.  Fixes #61 

The input prompt for adding a schema to the Schema Browser will now:
1. Validate the input to prevent duplicate entries.  Validation is performed on every keystroke, so checking for duplicates can be done in the validator, but verifying existence needs to wait until the user presses Enter.
![image](https://github.com/halcyon-tech/vscode-db2i/assets/134640655/40fc75e1-7173-4031-942b-1ace8d26b833)
2. Verify existence of the schema entered, displaying an error when it does not.  Unfortunately the `InputBox` construct does not seem to allow for validation upon the user pressing Enter, so for now it simply displays an error.  We could swizzle it to re-display the `InputBox` with the value prefilled and additional validation code that would highlight the value as an error.
![image](https://github.com/halcyon-tech/vscode-db2i/assets/134640655/dfac5cdf-f5e0-42c6-a229-b928f0c1dbe9)

Also added a schema browser for quickly adding one or more schemas.
![image](https://github.com/halcyon-tech/vscode-db2i/assets/134640655/7e8df469-42ea-4952-9801-6edd330a6d56)

Display includes the system schema name if different from the SQL name, as well as the text description.
![image](https://github.com/halcyon-tech/vscode-db2i/assets/134640655/39511a9b-0f43-4a52-8678-551c7f59358c)

List filtering capability is provided by the `vscode.window.showQuickPick` API
![image](https://github.com/halcyon-tech/vscode-db2i/assets/134640655/fdc43025-4c88-4851-a91e-d69b01434109)


