### PR TITLE
Fix incorrect SQL job being closed

### DIFF
--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -70,7 +70,7 @@ export class SQLJobManager {
   }
 
   closeJobByName(name: string) {
-    const id = this.jobs.findIndex(info => info.name);
+    const id = this.jobs.findIndex(info => info.name === name);
     return this.closeJob(id);
   }
 


### PR DESCRIPTION
Simple fix to the `Close Job` action so that it closes the right job instead of always closing the first one.