### PR TITLE
Left align table headers and data on exported data

### DIFF
--- a/src/notebooks/logic/export.ts
+++ b/src/notebooks/logic/export.ts
@@ -114,24 +114,38 @@ export const exportNotebookAsHtml = vscode.commands.registerCommand(`vscode-db2i
                           }
   
                           if (fallbackToTable) {
-                            cellContents.push([
-                              `<table style="width: 100%; margin-left: auto; margin-right: auto;">`,
-                              `<thead>`,
-                              `<tr>`,
-                              columns.map(c => `<th>${c}</th>`).join(``),
-                              `</tr>`,
-                              `</thead>`,
-                              `<tbody>`,
-                              table.map(row => {
-                                return [
-                                  `<tr>`,
-                                  keys.map(key => `<td>${row[key]}</td>`).join(``),
-                                  `</tr>`
-                                ].join(``);
-                              }).join(``),
-                              `</tbody>`,
-                              `</table>`
-                            ].join(``));
+                            cellContents.push(
+                              [
+                                `<table style="width: 100%; margin-left: auto; margin-right: auto;">`,
+                                `<thead>`,
+                                `<tr>`,
+                                columns
+                                  .map(
+                                    (c) =>
+                                      `<th style="text-align: left;">${c}</th>`
+                                  )
+                                  .join(``),
+                                `</tr>`,
+                                `</thead>`,
+                                `<tbody>`,
+                                table
+                                  .map((row) => {
+                                    return [
+                                      `<tr>`,
+                                      keys
+                                        .map(
+                                          (key) =>
+                                            `<td style="text-align: left;">${row[key]}</td>`
+                                        )
+                                        .join(``),
+                                      `</tr>`,
+                                    ].join(``);
+                                  })
+                                  .join(``),
+                                `</tbody>`,
+                                `</table>`,
+                              ].join(``)
+                            );
                           }
                         } else {
                           // items.push(vscode.NotebookCellOutputItem.stderr(`No rows returned from statement.`));


### PR DESCRIPTION
Left align table headers and explicitly left align table data.

Sorry this is longer than expected, I have a enthusiastic auto-formatter getting involved. I can undo the formatting changes if that's a dealbreaker.

This left aligns the column headers on the exported tables, and explicitly left aligns the table data.

![image](https://github.com/user-attachments/assets/a6dc8bd6-9ce8-477d-8ebc-0bfb548f21ce)

With the table spanning the whole page, two column layouts look very strange with the headers center-aligned and the data left-aligned.