### PR TITLE
Added default run all keybind #361

### DIFF
--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -212,8 +212,8 @@
       },
       {
         "command": "vscode-db2i.runEditorStatement.multiple.all",
-        "key": "ctrl+r a",
-        "mac": "cmd+r a",
+        "key": "ctrl+alt+a",
+        "mac": "cmd+alt+a",
         "when": "editorLangId == sql && resourceExtname != .inb"
       },
       {


### PR DESCRIPTION
For [#361](https://github.com/codefori/vscode-db2i/issues/361): 
- Customer suggested command/control + A + R
- VSCODE doesn't accept modifer + multiple keys. Tested locally, and it showed as 'unknown'. Documentation / editor allows for [key chords](https://code.visualstudio.com/docs/configure/keybindings#_accepted-keys). Settled on CTRL + a 