### PR TITLE
Ignore commented lines when using `update` prefix 

### DIFF
--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -264,6 +264,7 @@ async function runHandler(options?: StatementInfo) {
   vscode.commands.executeCommand('vscode-db2i.dove.close');
 
   if (optionsIsValid || (editor && editor.document.languageId === `sql`)) {
+    const eol = editor.document.eol === vscode.EndOfLine.CRLF ? `\r\n` : `\n`;
     let chosenView = resultSetProvider;
 
     const useWindow = (title: string, column?: ViewColumn) => {
@@ -377,7 +378,6 @@ async function runHandler(options?: StatementInfo) {
               updatableTable = refs[0];
             }
 
-            const eol = editor.document.eol === vscode.EndOfLine.CRLF ? `\r\n` : `\n`;
             const basicSelect = statementDetail.content.split(eol).filter(line => !line.trimStart().startsWith(`--`)).join(eol);
 
             chosenView.setScrolling({ // Never errors


### PR DESCRIPTION
Fixes #386

Testable using:
```sql
update: select * from sample.employee
--  where job = 'MANAGER'
order by empno;
```