### PR TITLE
Add support for adding custom examples to `Examples` view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.13.3",
+      "version": "1.14.0",
       "dependencies": {
         "@ibm/mapepire-js": "^0.5.0",
         "@octokit/rest": "^21.1.1",

--- a/package.json
+++ b/package.json
@@ -794,6 +794,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "vscode-db2i.examples.save",
+        "title": "Save As New Example",
+        "category": "Db2 for i (Examples)",
+        "icon": "$(save)"
+      },
+      {
         "command": "vscode-db2i.examples.add",
         "title": "Add...",
         "category": "Db2 for i (Examples)"
@@ -1115,13 +1121,18 @@
           "when": "view == exampleBrowser"
         },
         {
-          "submenu": "vscode-db2i.customExampleDirectories",
+          "command": "vscode-db2i.examples.save",
           "group": "navigation@2",
           "when": "view == exampleBrowser"
         },
         {
-          "command": "vscode-db2i.examples.reload",
+          "submenu": "vscode-db2i.customExampleDirectories",
           "group": "navigation@3",
+          "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@4",
           "when": "view == exampleBrowser"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
               "type": "string",
               "description": "The directory containing SQL example files."
             },
-            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment at the top of the file with the tags `category` and `description`.",
+            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment in the file with the tags `category` and `description`.",
             "default": []
           }
         }

--- a/package.json
+++ b/package.json
@@ -1371,6 +1371,16 @@
           "group": "navigation_notebook@1"
         }
       ],
+      "vscode-db2i.customExampleDirectories": [
+        {
+          "command": "vscode-db2i.examples.add",
+          "group": "navigation@0"
+        },
+        {
+          "command": "vscode-db2i.examples.remove",
+          "group": "navigation@1"
+        }
+      ],
       "notebook/toolbar": [
         {
           "command": "vscode-db2i.notebook.exportAsHtml",
@@ -1388,7 +1398,7 @@
       {
         "id": "vscode-db2i.customExampleDirectories",
         "label": "Custom Example Directories",
-        "icon": "$(sparkle)"
+        "icon": "$(folder-library)"
       }
     ],
     "keybindings": [
@@ -1509,18 +1519,6 @@
       {
         "view": "vscode-db2i.self.nodes",
         "contents": "🛠️ SELF Codes will appear here. You can set the SELF log level on specific jobs, or you can set the default for new jobs in the User Settings.\n\n[Set Default for New Jobs](command:vscode-db2i.jobManager.defaultSettings)\n\n[Learn about SELF](command:vscode-db2i.self.help)"
-      }
-    ],
-    "vscode-db2i.customExampleDirectories": [
-      {
-        "command": "vscode-db2i.examples.add",
-        "group": "navigation@0",
-        "when": "view == exampleBrowser"
-      },
-      {
-        "command": "vscode-db2i.examples.remove",
-        "group": "navigation@1",
-        "when": "view == exampleBrowser"
       }
     ],
     "notebooks": [

--- a/package.json
+++ b/package.json
@@ -794,6 +794,21 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "vscode-db2i.examples.add",
+        "title": "Add...",
+        "category": "Db2 for i (Examples)"
+      },
+      {
+        "command": "vscode-db2i.examples.remove",
+        "title": "Remove...",
+        "category": "Db2 for i (Examples)"
+      },
+      {
+        "command": "vscode-db2i.examples.edit",
+        "title": "Edit Example",
+        "category": "Db2 for i (Examples)"
+      },
+      {
         "command": "vscode-db2i.notebook.fromSqlUri",
         "title": "Open as Notebook",
         "category": "IBM i Notebooks",
@@ -1100,8 +1115,13 @@
           "when": "view == exampleBrowser"
         },
         {
-          "command": "vscode-db2i.examples.reload",
+          "submenu": "vscode-db2i.customExampleDirectories",
           "group": "navigation@2",
+          "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@3",
           "when": "view == exampleBrowser"
         }
       ],
@@ -1274,6 +1294,11 @@
           "command": "vscode-db2i.self.explainSelf",
           "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeNode && vscode-db2i:continueExtensionActive",
           "group": "navigation"
+        },
+        {
+          "command": "vscode-db2i.examples.edit",
+          "when": "view == exampleBrowser && viewItem == example.custom",
+          "group": "0_open"
         }
       ],
       "editor/title": [
@@ -1348,6 +1373,11 @@
         "icon": "$(notebook-execute)",
         "id": "sql/editor/context",
         "label": "Run SQL statement"
+      },
+      {
+        "id": "vscode-db2i.customExampleDirectories",
+        "label": "Custom Example Directories",
+        "icon": "$(sparkle)"
       }
     ],
     "keybindings": [
@@ -1468,6 +1498,18 @@
       {
         "view": "vscode-db2i.self.nodes",
         "contents": "🛠️ SELF Codes will appear here. You can set the SELF log level on specific jobs, or you can set the default for new jobs in the User Settings.\n\n[Set Default for New Jobs](command:vscode-db2i.jobManager.defaultSettings)\n\n[Learn about SELF](command:vscode-db2i.self.help)"
+      }
+    ],
+    "vscode-db2i.customExampleDirectories": [
+      {
+        "command": "vscode-db2i.examples.add",
+        "group": "navigation@0",
+        "when": "view == exampleBrowser"
+      },
+      {
+        "command": "vscode-db2i.examples.remove",
+        "group": "navigation@1",
+        "when": "view == exampleBrowser"
       }
     ],
     "notebooks": [

--- a/package.json
+++ b/package.json
@@ -973,6 +973,10 @@
           "when": "never"
         },
         {
+          "command": "vscode-db2i.examples.edit",
+          "when": "never"
+        },
+        {
           "command": "vscode-db2i.notebook.fromSqlUri",
           "when": "never"
         }

--- a/package.json
+++ b/package.json
@@ -256,6 +256,21 @@
         }
       },
       {
+        "id": "vscode-db2i.examples",
+        "title": "Examples",
+        "properties": {
+          "vscode-db2i.examples.customExampleDirectories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The directory containing SQL example files."
+            },
+            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment at the top of the file with the tags `category` and `description`.",
+            "default": []
+          }
+        }
+      },
+      {
         "id": "vscode-db2i.syntax",
         "title": "SQL Syntax Options",
         "properties": {
@@ -773,6 +788,12 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "vscode-db2i.examples.reload",
+        "title": "Refresh Examples",
+        "category": "Db2 for i (Examples)",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "vscode-db2i.notebook.fromSqlUri",
         "title": "Open as Notebook",
         "category": "IBM i Notebooks",
@@ -999,13 +1020,13 @@
           "when": "view == vscode-db2i.dove.node"
         },
         {
-          "command": "vscode-db2i.queryHistory.clear",
-          "group": "navigation",
+          "command": "vscode-db2i.queryHistory.find",
+          "group": "navigation@0",
           "when": "view == queryHistory"
         },
         {
-          "command": "vscode-db2i.queryHistory.find",
-          "group": "navigation",
+          "command": "vscode-db2i.queryHistory.clear",
+          "group": "navigation@1",
           "when": "view == queryHistory"
         },
         {
@@ -1070,12 +1091,17 @@
         },
         {
           "command": "vscode-db2i.examples.setFilter",
-          "group": "navigation",
+          "group": "navigation@0",
           "when": "view == exampleBrowser"
         },
         {
           "command": "vscode-db2i.examples.clearFilter",
-          "group": "navigation",
+          "group": "navigation@1",
+          "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@2",
           "when": "view == exampleBrowser"
         }
       ],

--- a/src/notebooks/logic/statement.ts
+++ b/src/notebooks/logic/statement.ts
@@ -18,7 +18,8 @@ export function getStatementDetail(content: string, eol: string) {
     const lines = content.split(eol);
     const firstNonCommentLine = lines.findIndex(line => !line.startsWith(`--`));
 
-    const startingComments = lines.slice(0, firstNonCommentLine).map(line => line.substring(2).trim());
+    const startingCommentLines = firstNonCommentLine === -1 ? lines : lines.slice(0, firstNonCommentLine);
+    const startingComments = startingCommentLines.map(line => line.substring(2).trim());
     content = lines.slice(firstNonCommentLine).join(eol);
 
     for (let comment of startingComments) {

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -22,21 +22,49 @@
         "title": "Clear filter",
         "category": "Db2 for i (Examples)",
         "icon": "$(clear-all)"
+      },
+      {
+        "command": "vscode-db2i.examples.reload",
+        "title": "Refresh Examples",
+        "category": "Db2 for i (Examples)",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
       "view/title": [
         {
           "command": "vscode-db2i.examples.setFilter",
-          "group": "navigation",
+          "group": "navigation@0",
           "when": "view == exampleBrowser"
         },
         {
           "command": "vscode-db2i.examples.clearFilter",
-          "group": "navigation",
+          "group": "navigation@1",
+          "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@2",
           "when": "view == exampleBrowser"
         }
       ]
-    }
+    },
+    "configuration": [
+      {
+        "id": "vscode-db2i.examples",
+        "title": "Examples",
+        "properties": {
+          "vscode-db2i.examples.customExampleDirectories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The directory containing SQL example files."
+            },
+            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment at the top of the file with the tags `category` and `description`.",
+            "default": []
+          }
+        }
+      }
+    ]
   }
 }

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -60,7 +60,7 @@
               "type": "string",
               "description": "The directory containing SQL example files."
             },
-            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment at the top of the file with the tags `category` and `description`.",
+            "markdownDescription": "Set of custom directories containing SQL example files to be shown in the `Examples` view. All SQL files in the specified directories and at most one subdirectory level deeper will be picked up.\n\nBy default, the folder name will be the category and the file name will be the name of the example. This can be customized by optionally including a comment in the file with the tags `category` and `description`.",
             "default": []
           }
         }

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -28,6 +28,40 @@
         "title": "Refresh Examples",
         "category": "Db2 for i (Examples)",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "vscode-db2i.examples.add",
+        "title": "Add...",
+        "category": "Db2 for i (Examples)"
+      },
+      {
+        "command": "vscode-db2i.examples.remove",
+        "title": "Remove...",
+        "category": "Db2 for i (Examples)"
+      },
+      {
+        "command": "vscode-db2i.examples.edit",
+        "title": "Edit Example",
+        "category": "Db2 for i (Examples)"
+      }
+    ],
+    "submenus": [
+      {
+        "id": "vscode-db2i.customExampleDirectories",
+        "label": "Custom Example Directories",
+        "icon": "$(sparkle)"
+      }
+    ],
+    "vscode-db2i.customExampleDirectories": [
+      {
+        "command": "vscode-db2i.examples.add",
+        "group": "navigation@0",
+        "when": "view == exampleBrowser"
+      },
+      {
+        "command": "vscode-db2i.examples.remove",
+        "group": "navigation@1",
+        "when": "view == exampleBrowser"
       }
     ],
     "menus": {
@@ -43,9 +77,21 @@
           "when": "view == exampleBrowser"
         },
         {
-          "command": "vscode-db2i.examples.reload",
+          "submenu": "vscode-db2i.customExampleDirectories",
           "group": "navigation@2",
           "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@3",
+          "when": "view == exampleBrowser"
+        }
+      ],
+      "view/item/context": [
+        {
+        "command": "vscode-db2i.examples.edit",
+          "when": "view == exampleBrowser && viewItem == example.custom",
+          "group": "0_open"
         }
       ]
     },

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -30,6 +30,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "vscode-db2i.examples.save",
+        "title": "Save As New Example",
+        "category": "Db2 for i (Examples)",
+        "icon": "$(save)"
+      },
+      {
         "command": "vscode-db2i.examples.add",
         "title": "Add...",
         "category": "Db2 for i (Examples)"
@@ -77,19 +83,24 @@
           "when": "view == exampleBrowser"
         },
         {
-          "submenu": "vscode-db2i.customExampleDirectories",
+          "command": "vscode-db2i.examples.save",
           "group": "navigation@2",
           "when": "view == exampleBrowser"
         },
         {
-          "command": "vscode-db2i.examples.reload",
+          "submenu": "vscode-db2i.customExampleDirectories",
           "group": "navigation@3",
+          "when": "view == exampleBrowser"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@4",
           "when": "view == exampleBrowser"
         }
       ],
       "view/item/context": [
         {
-        "command": "vscode-db2i.examples.edit",
+          "command": "vscode-db2i.examples.edit",
           "when": "view == exampleBrowser && viewItem == example.custom",
           "group": "0_open"
         }

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -102,6 +102,12 @@
           "command": "vscode-db2i.examples.remove",
           "group": "navigation@1"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "vscode-db2i.examples.edit",
+          "when": "never"
+        }
       ]
     },
     "configuration": [

--- a/src/views/examples/contributes.json
+++ b/src/views/examples/contributes.json
@@ -55,19 +55,7 @@
       {
         "id": "vscode-db2i.customExampleDirectories",
         "label": "Custom Example Directories",
-        "icon": "$(sparkle)"
-      }
-    ],
-    "vscode-db2i.customExampleDirectories": [
-      {
-        "command": "vscode-db2i.examples.add",
-        "group": "navigation@0",
-        "when": "view == exampleBrowser"
-      },
-      {
-        "command": "vscode-db2i.examples.remove",
-        "group": "navigation@1",
-        "when": "view == exampleBrowser"
+        "icon": "$(folder-library)"
       }
     ],
     "menus": {
@@ -103,6 +91,16 @@
           "command": "vscode-db2i.examples.edit",
           "when": "view == exampleBrowser && viewItem == example.custom",
           "group": "0_open"
+        }
+      ],
+      "vscode-db2i.customExampleDirectories": [
+        {
+          "command": "vscode-db2i.examples.add",
+          "group": "navigation@0"
+        },
+        {
+          "command": "vscode-db2i.examples.remove",
+          "group": "navigation@1"
         }
       ]
     },

--- a/src/views/examples/index.ts
+++ b/src/views/examples/index.ts
@@ -18,6 +18,7 @@ export interface SQLExample {
   content: string[];
   requirements?: ExampleSystemRequirements;
   isNotebook?: boolean;
+  customFileUri?: Uri;
 };
 
 // Unlike the bulk of the examples defined below, the services examples are retrieved dynamically
@@ -6057,7 +6058,8 @@ export async function getCustomExamples(): Promise<SQLExamplesList> {
 
     examplesList[group].push({
       name: name,
-      content: textDocument.getText().split(eol)
+      content: textDocument.getText().split(eol),
+      customFileUri: textDocument.uri
     });
   }
 

--- a/src/views/examples/index.ts
+++ b/src/views/examples/index.ts
@@ -6075,17 +6075,24 @@ async function getSqlTextDocumentsFromDirectory(directory: Uri, depth = 1): Prom
       const uri = Uri.joinPath(directory, name);
 
       if (type === FileType.File) {
-        const textDocument = await workspace.openTextDocument(uri);
-        if (textDocument.languageId === 'sql') {
-          sqlTextDocuments.push(textDocument);
+        try {
+          const textDocument = await workspace.openTextDocument(uri);
+          if (textDocument.languageId === 'sql') {
+            sqlTextDocuments.push(textDocument);
+          }
+        } catch (error) {
+          // Ignore error reading file
+          console.log(error);
+          continue;
         }
       } else if (type === FileType.Directory && depth > 0) {
         const subContents = await getSqlTextDocumentsFromDirectory(uri, depth - 1);
         sqlTextDocuments.push(...subContents);
       }
     }
-  } catch {
-    // Ignore errors
+  } catch (error) {
+    // Ignore error reading directory
+    console.log(error);
   }
 
   return sqlTextDocuments;

--- a/src/views/queryHistoryView/contributes.json
+++ b/src/views/queryHistoryView/contributes.json
@@ -59,13 +59,13 @@
       ],
       "view/title": [
         {
-          "command": "vscode-db2i.queryHistory.clear",
-          "group": "navigation",
+          "command": "vscode-db2i.queryHistory.find",
+          "group": "navigation@0",
           "when": "view == queryHistory"
         },
         {
-          "command": "vscode-db2i.queryHistory.find",
-          "group": "navigation",
+          "command": "vscode-db2i.queryHistory.clear",
+          "group": "navigation@1",
           "when": "view == queryHistory"
         }
       ],


### PR DESCRIPTION
### Changes

This PR adds support for adding custom examples to the `Examples` view (similar to ACS).

- [x] Add `Custom Example Directories` setting
- [x] Auto refresh `Examples` view when setting change
- [x] Load all SQL files from custom directories and 1 subdirectory deeper into `Examples` view
- [x] Add watchers for custom example directories to refresh the view on additions, deletions, and changes
- [x] Set category name as parent folder or `category` tag from the comments
- [x] Set example name as file name or `description` tag from the comments
- [x] Add right-click `Edit Example` button for custom examples only
- [x] Added `Refresh Examples` button to `Examples` view
- [x] Add `Custom Examples Directory` submenu button to `Examples` view
  - [x] Add `Add...` button
  - [x] Add `Remove...` button
- [x] Add `Save As New Example` button
- [x] Update docs

Other:
- [x] Re-ordered actions in statement history view