### PR TITLE
Updated keyboard shortcuts for explaining and running

### DIFF
--- a/package.json
+++ b/package.json
@@ -1459,6 +1459,18 @@
         "when": "editorLangId == sql"
       },
       {
+        "command": "vscode-db2i.runEditorStatement.multiple.all",
+        "key": "ctrl+shift+a",
+        "mac": "cmd+shift+a",
+        "when": "editorLangId == sql && resourceExtname != .inb"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.from",
+        "key": "ctrl+shift+r",
+        "mac": "cmd+shift+r",
+        "when": "editorLangId == sql && resourceExtname != .inb"
+      },
+      {
         "command": "vscode-db2i.editorExplain.withRun",
         "key": "ctrl+u",
         "mac": "cmd+u",

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -216,6 +216,18 @@
         "when": "editorLangId == sql"
       },
       {
+        "command": "vscode-db2i.runEditorStatement.multiple.all",
+        "key": "ctrl+shift+a",
+        "mac": "cmd+shift+a",
+        "when": "editorLangId == sql && resourceExtname != .inb"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.from",
+        "key": "ctrl+shift+r",
+        "mac": "cmd+shift+r",
+        "when": "editorLangId == sql && resourceExtname != .inb"
+      },
+      {
         "command": "vscode-db2i.editorExplain.withRun",
         "key": "ctrl+u",
         "mac": "cmd+u",


### PR DESCRIPTION
This PR changes the default keyboard shortcuts for `Explain` and `Run and Explain` action so they don't overlap with other shortcuts like `Run in new view`.

<img width="362" height="238" alt="image" src="https://github.com/user-attachments/assets/a51e20f8-2658-4d88-b01e-27670f7f6487" />

- `Explain` is `ctrl+e`
- `Run and Explain`  is `ctrl+u`
- `Run from cursor`  is `ctrl+shift+r`
- `Run all`  is `ctrl+shift+a`

This is consistend with ACS's keybindings.