### PR TITLE
Fixed `runEditorStatement` command crashing when invoked with no editor opened

### DIFF
--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -1,27 +1,26 @@
 import * as vscode from "vscode";
-import crypto from "crypto";
-import { SnippetString, ViewColumn, TreeView, window } from "vscode"
+import { SnippetString, TreeView, ViewColumn, window } from "vscode";
 
 import * as csv from "csv/sync";
 
 import { JobManager } from "../../config";
-import Document from "../../language/sql/document";
-import { ObjectRef, ParsedEmbeddedStatement, StatementGroup, StatementType } from "../../language/sql/types";
-import Statement from "../../language/sql/statement";
-import { ExplainTree } from "./explain/nodes";
-import { DoveResultsView, ExplainTreeItem } from "./explain/doveResultsView";
-import { DoveNodeView, PropertyNode } from "./explain/doveNodeView";
-import { DoveTreeDecorationProvider } from "./explain/doveTreeDecorationProvider";
-import { ResultSetPanelProvider, SqlParameter } from "./resultSetPanelProvider";
-import { generateSqlForAdvisedIndexes } from "./explain/advice";
-import { updateStatusBar } from "../jobManager/statusBar";
-import { DbCache } from "../../language/providers/logic/cache";
-import { ExplainType } from "../../connection/types";
-import { queryResultToRpgDs } from "./codegen";
 import Configuration from "../../configuration";
+import { ExplainType } from "../../connection/types";
+import { DbCache } from "../../language/providers/logic/cache";
 import { getSqlDocument } from "../../language/providers/logic/parse";
+import Document from "../../language/sql/document";
+import Statement from "../../language/sql/statement";
+import { ObjectRef, ParsedEmbeddedStatement, StatementGroup, StatementType } from "../../language/sql/types";
+import { updateStatusBar } from "../jobManager/statusBar";
 import { getLiteralsFromStatement, getPriorBindableStatement } from "./binding";
+import { queryResultToRpgDs } from "./codegen";
 import { registerRunStatement } from "./editorUi";
+import { generateSqlForAdvisedIndexes } from "./explain/advice";
+import { DoveNodeView, PropertyNode } from "./explain/doveNodeView";
+import { DoveResultsView, ExplainTreeItem } from "./explain/doveResultsView";
+import { DoveTreeDecorationProvider } from "./explain/doveTreeDecorationProvider";
+import { ExplainTree } from "./explain/nodes";
+import { ResultSetPanelProvider, SqlParameter } from "./resultSetPanelProvider";
 
 export type StatementQualifier = "statement" | "bind" | "update" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql" | "rpg";
 
@@ -379,7 +378,7 @@ async function runHandler(options?: StatementInfo) {
             }
 
             const uiId = registerRunStatement(statementDetail);
-            const eol = editor.document.eol === vscode.EndOfLine.CRLF ? `\r\n` : `\n`;
+            const eol = editor?.document.eol === vscode.EndOfLine.CRLF ? `\r\n` : `\n`;
             const basicSelect = statementDetail.content.split(eol).filter(line => !line.trimStart().startsWith(`--`)).join(eol);
 
             chosenView.setScrolling({ // Never errors


### PR DESCRIPTION
This PR fixes a crash that happens when the is invoked to run a statement but there is no editor opened. This error shows in the view:
<img width="427" height="70" alt="image" src="https://github.com/user-attachments/assets/bb31bc1a-6d97-4577-acc7-2f5b5b239c04" />

The error can be reproduced by running `Get Authorities` from the schema browser with no editor opened:
<img width="274" height="181" alt="image" src="https://github.com/user-attachments/assets/babf1da5-fbc1-4fc5-98e6-c5c66a217cf3" />

After the PR is applied, the error is gone and the statements run fine.