### PR TITLE
Fix actions on quoted database objects

### DIFF
--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { getInstance } from "../base";
 import { JobManager } from "../config";
 import { ResolvedSqlObject, BasicSQLObject } from "../types";
+import Statement from "./statement";
 
 export type SQLType = "schemas" | "tables" | "views" | "aliases" | "constraints" | "functions" | "variables" | "indexes" | "procedures" | "sequences" | "packages" | "triggers" | "types" | "logicals";
 export type PageData = { filter?: string, offset?: number, limit?: number, sort?: boolean };
@@ -475,7 +476,7 @@ export default class Schemas {
 
       await JobManager.runSQL<{ SRCDTA: string }>([
         `CALL QSYS2.GENERATE_SQL( ${options.join(`, `)} )`,
-      ].join(` `), { parameters: [object, schema, internalType] });
+      ].join(` `), { parameters: [Statement.escapeString(object), Statement.escapeString(schema), internalType] });
 
       // TODO: eventually .content -> .getContent(), it's not available yet
       const contents = (
@@ -494,7 +495,7 @@ export default class Schemas {
     type: string
   ): Promise<void> {
     const query = `DROP ${(this.isRoutineType(type) ? "SPECIFIC " : "") + type
-      } IF EXISTS ${schema}.${name}`;
+      } IF EXISTS ${Statement.delimName(schema)}.${Statement.delimName(name)}`;
     await getInstance().getContent().runSQL(query);
   }
 
@@ -505,7 +506,7 @@ export default class Schemas {
     type: string
   ): Promise<void> {
     const query = `RENAME ${type === "view" ? "table" : type
-      } ${schema}.${oldName} TO ${newName}`;
+      } ${Statement.delimName(schema)}.${Statement.delimName(oldName)} TO ${Statement.delimName(newName)}`;
     await getInstance().getContent().runSQL(query);
   }
 
@@ -514,10 +515,10 @@ export default class Schemas {
   }
 
   static clearAdvisedIndexes(schema: string, name?: string) {
-    let query = `DELETE FROM QSYS2.SYSIXADV WHERE TABLE_SCHEMA = '${schema}'`;
+    let query = `DELETE FROM QSYS2.SYSIXADV WHERE TABLE_SCHEMA = '${Statement.escapeString(schema)}'`;
 
     if (name) {
-      query += `and TABLE_NAME = '${name}'`;
+      query += `and TABLE_NAME = '${Statement.escapeString(name)}'`;
     }
 
     return getInstance().getContent().runSQL(query);

--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -44,14 +44,14 @@ export default class Statement {
       // If already delimited, return it as-is
       if (name.startsWith(`"`) && name.endsWith(`"`)) return name;
       // If the value contains a space or decimal it needs to be delimited
-      if (name.includes(` `) || name.includes(`.`)) return `"${name}"`;
+      if (name.includes(` `) || name.includes(`.`) || name.includes(`'`)) return `"${name}"`;
       // Otherwise, fold to uppercase.  The user should have explicitly delimited if that was their intention.
       return name.toUpperCase();
     } else { // The name came from a catalog file query
       // If the name contains characters other than the valid variants, uppercase, digits, or underscores, it must be delimited
       if (Statement.validQsysName(name)) return name;
       else {
-        if (name.includes(` `) || name.includes(`.`) || name !== name.toUpperCase()) {
+        if (name.includes(` `) || name.includes(`.`) || name.includes(`'`) || name !== name.toUpperCase()) {
           return `"${name}"`;
         } else {
           return name;
@@ -83,24 +83,10 @@ export default class Statement {
   }
 
   static escapeString(value: string) {
-    value = value.replace(/[\0\n\r\b\t'\x1a]/g, function (s) {
+    value = value.replace(/'/g, function (s) {
       switch (s) {
-        case `\0`:
-          return `\\0`;
-        case `\n`:
-          return `\\n`;
-        case `\r`:
-          return ``;
-        case `\b`:
-          return `\\b`;
-        case `\t`:
-          return `\\t`;
-        case `\x1a`:
-          return `\\Z`;
         case `'`:
           return `''`;
-        default:
-          return `\\` + s;
       }
     });
   

--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -2,6 +2,7 @@
 import { JobManager } from "../config";
 import { getInstance } from "../base";
 import { TableColumn, CPYFOptions } from "../types";
+import Statement from "./statement";
 
 export default class Table {
   /**
@@ -79,7 +80,7 @@ export default class Table {
   }
 
   static async clearFile(library: string, objectName: string): Promise<void> {
-    const command = `CLRPFM ${library}/${objectName}`;
+    const command = `CLRPFM ${Statement.escapeString(library)}/${Statement.escapeString(objectName)}`;
               
     const commandResult = await getInstance().getConnection().runCommand({
       command: command,
@@ -93,7 +94,7 @@ export default class Table {
 
   static async copyFile(library: string, objectName: string, options: CPYFOptions): Promise<void> {
     const command = [
-      `CPYF FROMFILE(${library}/${objectName}) TOFILE(${options.toLib}/${options.toFile})`,
+      `CPYF FROMFILE(${Statement.escapeString(library)}/${Statement.escapeString(objectName)}) TOFILE(${options.toLib}/${options.toFile})`,
       `FROMMBR(${options.fromMbr}) TOMBR(${options.toMbr}) MBROPT(${options.mbrOpt})`,
       `CRTFILE(${options.crtFile}) OUTFMT(${options.outFmt})`
     ].join(` `);


### PR DESCRIPTION
This PR fixes actions performed on quoted schemas / database objects:
- `Clear`
- `Copy Data`
- `Delete`
- `Rename`
- `View Permissions`
- `Advised Indexes`
- `Get Related Objects`
- `Get Indexes`
- Get MTIs
- `Get Authorities`
- `Get Object Locks`
- `Get Record Locks`