### PR TITLE
Save update prefix statement to statement history

### DIFF
--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -13,7 +13,7 @@ import { TableColumn } from "../../types";
 import { statementDone } from "./editorUi";
 import { QueryResult } from "@ibm/mapepire-js";
 
-export type SqlParameter = string|number;
+export type SqlParameter = string | number;
 
 export interface ScrollerOptions {
   uiId?: string;
@@ -79,7 +79,12 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
             console.log(message);
             try {
               const result = await JobManager.runSQL(message.update, { parameters: message.bindings });
-              commands.executeCommand(`vscode-db2i.queryHistory.prepend`, message.update);
+              const substatement = message.bindings
+                ? `bind: ${message.bindings
+                  .map(binding => typeof binding === 'string' ? `'${binding}'` : String(binding))
+                  .join(', ')}`
+                : undefined;
+              commands.executeCommand(`vscode-db2i.queryHistory.prepend`, message.update, substatement);
               postCellResponse(message.id, true);
             } catch (e) {
               // this.setError(e.message);
@@ -113,7 +118,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 let queryResults: QueryResult<any> = undefined;
                 let startTime = 0;
                 let endTime = 0;
-                let executionTime: number|undefined;
+                let executionTime: number | undefined;
 
                 if (this.currentQuery.getState() == "RUN_MORE_DATA_AVAILABLE") {
                   queryResults = await this.currentQuery.fetchMore();
@@ -125,7 +130,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                   executionTime = (endTime - startTime);
 
                   if (message.uiId) {
-                    statementDone(message.uiId, {paramsOut: queryResults.output_parms});
+                    statementDone(message.uiId, { paramsOut: queryResults.output_parms });
                   }
                 }
                 const jobId = this.currentQuery.getHostJob().id;


### PR DESCRIPTION
This PR adds the executed update statement to the `Statement History` view. Note that the `?` markers are kept as is. This is consistent with how the current `bind` prefix adds to the history.

Fixes #462

<img width="922" height="164" alt="image" src="https://github.com/user-attachments/assets/f7d474f7-a286-4e46-b8be-4fde704b7463" />
