### PR TITLE
Fix missing whitespace in job log's `MESSAGE_TEXT` and `MESSAGE_SECOND_LEVEL_TEXT`

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -36,7 +36,7 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
     }
 
     #resultset td.preserve {
-      white-space: pre-wrap; /* preserves spaces AND wraps lines */
+      white-space: pre-wrap;
     }
 
     #resultset tbody tr:hover {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -35,6 +35,10 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
       padding: 5px 15px;
     }
 
+    #resultset td.preserve {
+      white-space: pre-wrap; /* preserves spaces AND wraps lines */
+    }
+
     #resultset tbody tr:hover {
       background-color: var(--vscode-list-hoverBackground);
     }

--- a/src/views/jobManager/jobLog.ts
+++ b/src/views/jobManager/jobLog.ts
@@ -51,12 +51,8 @@ function generatePage(rows: JobLogEntry[]) {
                 <td>
                   ${row.MESSAGE_ID}
                 </td>
-                <td>
-                  ${escapeHTML(row.MESSAGE_TEXT || ``)}
-                </td>
-                <td>
-                  ${escapeHTML(row.MESSAGE_SECOND_LEVEL_TEXT || ``)}
-                </td>
+                <td class="preserve">${escapeHTML(row.MESSAGE_TEXT || ``)}</td>
+                <td class="preserve">${escapeHTML(row.MESSAGE_SECOND_LEVEL_TEXT || ``)}</td>
               </tr>`
             }).join(``)}
           </tbody>


### PR DESCRIPTION
Fixes #473

This PR adds missing whitespace in the job log's `MESSAGE_TEXT` and `MESSAGE_SECOND_LEVEL_TEXT`. This fix is testable with the example in the linked issue above:

```sql
BEGIN
    DECLARE seg_PMCU CHAR(12);
    SET seg_PMCU = LPAD('MED', 12, ' ');

    CALL SYSTOOLS.LPRINTF('--- DEBUGGING --------------------------------------');
    CALL SYSTOOLS.LPRINTF('BRANCH ['|| seg_PMCU ||']');
    CALL SYSTOOLS.LPRINTF('BRANCH ['|| HEX(seg_PMCU) ||']');
END;
```

**Before:**
<img width="736" height="116" alt="image" src="https://github.com/user-attachments/assets/b99e00f0-931f-45e5-97c1-d77344aa16b4" />


**After:**
<img width="1064" height="163" alt="image" src="https://github.com/user-attachments/assets/57c25c7f-5457-4620-ad94-3ee77588b770" />