### PR TITLE
Add missing `Open SQL Document` shortcut to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1484,6 +1484,11 @@
         "when": "editorLangId == sql && resourceExtname != .inb"
       },
       {
+        "command": "vscode-db2i.openSqlDocument",
+        "key": "ctrl+alt+n",
+        "mac": "cmd+alt+n"
+      },
+      {
         "command": "notebook.cell.execute",
         "key": "ctrl+r",
         "mac": "cmd+r",


### PR DESCRIPTION
This is just a follow up to https://github.com/codefori/vscode-db2i/pull/412 to add the keybind in the `package.json`.