### PR TITLE
add explainTree command returning ExplainTreeNode for visual explain data

### DIFF
--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -151,6 +151,12 @@ export function initialise(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`vscode-db2i.dove.closeDetails`, () => {
       doveNodeView.close();
     }),
+    //adding an API to expose creating explain tree from vedata to get visual explain details
+    vscode.commands.registerCommand(`vscode-db2i.explain.explainTree`, (vedata: any) => {
+      explainTree = new ExplainTree(vedata);
+      const topLevel = explainTree.get();
+      return topLevel;
+    }),
 
     vscode.commands.registerCommand(`vscode-db2i.runEditorStatement.multiple.all`, () => { runMultipleHandler(`all`) }),
     vscode.commands.registerCommand(`vscode-db2i.runEditorStatement.multiple.selected`, () => { runMultipleHandler(`selected`) }),


### PR DESCRIPTION
## Summary

Adds a new VS Code command `vscode-db2i.explain.explainTree` which constructs an `ExplainTree` from the provided `vedata` and returns the generated top-level `ExplainTreeNode` to get structured visual explain data.

## Changes

* Registered new command: `vscode-db2i.explain.explainTree`
* Reuses existing `ExplainTree` logic to generate the tree structure
* Returns the top-level node via `explainTree.get()`
* No new logic or functionality was implemented.
* This change only exposes the existing logic through a newly registered command.

## Why

This command is required for the **BOB MCP tool** to retrieve **visual explain data** in a **proper structured format** from vedata, so it can be rendered correctly in MCP tool.

