### PR TITLE
Bump Mapepire-Server to 2.3.4

### DIFF
--- a/src/connection/SCVersion.ts
+++ b/src/connection/SCVersion.ts
@@ -1,4 +1,4 @@
 
-export const VERSION = `2.3.3`;
+export const VERSION = `2.3.4`;
 export const SERVER_VERSION_TAG = `v${VERSION}`;
 export const SERVER_VERSION_FILE = `mapepire-server-${VERSION}.jar`;


### PR DESCRIPTION
Bump Mapepire-Server to 2.3.4 so it matches the version delivered with the upcoming Code for i 3.0.0 version.