### PR TITLE
Refresh query history when connecting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,9 @@ import * as JSONServices from "./language/json";
 import * as resultsProvider from "./views/results";
 
 import { JDBCOptions } from "@ibm/mapepire-js/dist/src/types";
+import { registerContinueProvider } from "./aiProviders/continue/continueContextProvider";
+import { registerDb2iTablesProvider } from "./aiProviders/continue/listTablesContextProvider";
+import { registerCopilotProvider } from "./aiProviders/copilot";
 import { getInstance, loadBase } from "./base";
 import { JobManager, initConfig, onConnectOrServerInstall } from "./config";
 import Configuration from "./configuration";
@@ -15,18 +18,15 @@ import { ServerComponent } from "./connection/serverComponent";
 import { OldSQLJob } from "./connection/sqlJob";
 import { languageInit } from "./language/providers";
 import { DbCache } from "./language/providers/logic/cache";
+import { setCheckerAvailableContext } from "./language/providers/problemProvider";
 import { notebookInit } from "./notebooks/IBMiSerializer";
 import { initialiseTestSuite } from "./testing";
 import { Db2iUriHandler, getStatementUri } from "./uriHandler";
+import { SQLExamples } from "./views/examples";
 import { ExampleBrowser } from "./views/examples/exampleBrowser";
 import { JobManagerView } from "./views/jobManager/jobManagerView";
-import { SelfTreeDecorationProvider, SelfCodesResultsView } from "./views/jobManager/selfCodes/selfCodesResultsView";
-import { registerContinueProvider } from "./aiProviders/continue/continueContextProvider";
+import { SelfCodesResultsView, SelfTreeDecorationProvider } from "./views/jobManager/selfCodes/selfCodesResultsView";
 import { QueryHistory } from "./views/queryHistoryView";
-import { registerCopilotProvider } from "./aiProviders/copilot";
-import { registerDb2iTablesProvider } from "./aiProviders/continue/listTablesContextProvider";
-import { setCheckerAvailableContext } from "./language/providers/problemProvider";
-import { SQLExamples } from "./views/examples";
 
 export interface Db2i {
   sqlJobManager: SQLJobManager,
@@ -94,7 +94,9 @@ export function activate(context: vscode.ExtensionContext): Db2i {
     setCheckerAvailableContext();
     // Refresh the examples when we have it, so we only display certain examples
     onConnectOrServerInstall().then(() => {
+      schemaBrowser.clearCacheAndRefresh();
       exampleBrowser.refresh();
+      queryHistory.refresh();
       selfCodesView.setRefreshEnabled(Configuration.get(`jobSelfViewAutoRefresh`) || false);
       // register list tables
       const currentJob = JobManager.getSelection();

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -1,19 +1,19 @@
 
-import { ThemeIcon, TreeItem, workspace, window } from "vscode"
-import * as vscode from "vscode"
-import Schemas, { AllSQLTypes, InternalTypes, SQL_ESCAPE_CHAR, SQLType } from "../../database/schemas";
+import * as vscode from "vscode";
+import { ThemeIcon, TreeItem, window, workspace } from "vscode";
+import { getInstance } from "../../base";
+import Schemas, { AllSQLTypes, InternalTypes, SQLType } from "../../database/schemas";
 import Table from "../../database/table";
-import { getInstance, loadBase } from "../../base";
 
 import Configuration from "../../configuration";
 
-import Types from "../types";
-import Statement from "../../database/statement";
-import { getCopyUi } from "./copyUI";
-import { getAdvisedIndexesStatement, getIndexesStatement, getMTIStatement, getAuthoritiesStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects } from "./statements";
-import { BasicSQLObject } from "../../types";
-import { TextDecoder } from "util";
 import { parse } from "csv/sync";
+import { TextDecoder } from "util";
+import Statement from "../../database/statement";
+import { BasicSQLObject } from "../../types";
+import Types from "../types";
+import { getCopyUi } from "./copyUI";
+import { getAdvisedIndexesStatement, getAuthoritiesStatement, getIndexesStatement, getMTIStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects } from "./statements";
 
 const itemIcons = {
   "table": `split-horizontal`,
@@ -442,8 +442,6 @@ export default class SchemaBrowser {
         }
       })
     )
-
-    getInstance().subscribe(context, `connected`, `db2i-clearCacheAndRefresh`, () => this.clearCacheAndRefresh());
   }
 
   async pickFile(): Promise<vscode.Uri | undefined> {


### PR DESCRIPTION
This PR makes the Query History to refresh itself after connecting to an IBM i.

So far, it would only load its items on the first connection. Disconnecting and connecting to a different LPAR would still show the history from the previous connection.

The schema browser refresh has also been moved with the other view refreshes (no need to have multiple subscription to the `connect` event here).