### PR TITLE
Fixed schema browser issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1355,12 +1355,12 @@
         },
         {
           "command": "vscode-db2i.getAuthorities",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == receiver || viewItem == journal || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == receiver || viewItem == journal || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2workWith@4"
         },
         {
           "command": "vscode-db2i.getObjectLocks",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2workWith@5"
         },
         {
@@ -1380,12 +1380,12 @@
         },
         {
           "command": "vscode-db2i.deleteObject",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == mask || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == permission || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == mask || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == permission || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2data@3"
         },
         {
           "command": "vscode-db2i.renameObject",
-          "when": "viewItem == table || viewItem == view || viewItem == index",
+          "when": "viewItem == table || viewItem == view || viewItem == index || viewItem == logical",
           "group": "db2data@4"
         },
         {

--- a/src/views/schemaBrowser/contributes.json
+++ b/src/views/schemaBrowser/contributes.json
@@ -231,12 +231,12 @@
         },
         {
           "command": "vscode-db2i.getAuthorities",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == receiver || viewItem == journal || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == receiver || viewItem == journal || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2workWith@4"
         },
         {
           "command": "vscode-db2i.getObjectLocks",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2workWith@5"
         },
         {
@@ -256,12 +256,12 @@
         },
         {
           "command": "vscode-db2i.deleteObject",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == mask || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == permission || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == mask || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == permission || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type || viewItem == logical",
           "group": "db2data@3"
         },
         {
           "command": "vscode-db2i.renameObject",
-          "when": "viewItem == table || viewItem == view || viewItem == index",
+          "when": "viewItem == table || viewItem == view || viewItem == index || viewItem == logical",
           "group": "db2data@4"
         },
         {

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -1,19 +1,19 @@
 
-import { ThemeIcon, TreeItem, workspace, window } from "vscode"
-import * as vscode from "vscode"
-import Schemas, { AllSQLTypes, InternalTypes, SQL_ESCAPE_CHAR, SQLType } from "../../database/schemas";
+import * as vscode from "vscode";
+import { ThemeIcon, TreeItem, window, workspace } from "vscode";
+import { getInstance } from "../../base";
+import Schemas, { AllSQLTypes, InternalTypes, SQLType } from "../../database/schemas";
 import Table from "../../database/table";
-import { getInstance, loadBase } from "../../base";
 
 import Configuration from "../../configuration";
 
-import Types from "../types";
-import Statement from "../../database/statement";
-import { getCopyUi } from "./copyUI";
-import { getAdvisedIndexesStatement, getIndexesStatement, getMTIStatement, getAuthoritiesStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects } from "./statements";
-import { BasicSQLObject } from "../../types";
-import { TextDecoder } from "util";
 import { parse } from "csv/sync";
+import { TextDecoder } from "util";
+import Statement from "../../database/statement";
+import { BasicSQLObject } from "../../types";
+import Types from "../types";
+import { getCopyUi } from "./copyUI";
+import { getAdvisedIndexesStatement, getAuthoritiesStatement, getIndexesStatement, getMTIStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects } from "./statements";
 
 const itemIcons = {
   "table": `split-horizontal`,
@@ -207,7 +207,7 @@ export default class SchemaBrowser {
 
       vscode.commands.registerCommand(`vscode-db2i.getAuthorities`, async (object: SQLObject) => {
         if (object) {
-          const content = getAuthoritiesStatement(object.system.schema, object.system.name, object.type.toUpperCase(), object.tableType);
+          const content = getAuthoritiesStatement(object.schema, object.name, object.type.toUpperCase(), object.tableType);
           vscode.commands.executeCommand(`vscode-db2i.runEditorStatement`, {
             content,
             qualifier: `statement`,
@@ -218,7 +218,7 @@ export default class SchemaBrowser {
 
       vscode.commands.registerCommand(`vscode-db2i.getObjectLocks`, async (object: SQLObject) => {
         if (object) {
-          const content = getObjectLocksStatement(object.system.schema, object.system.name, object.type.toUpperCase(), object.tableType);
+          const content = getObjectLocksStatement(object.schema, object.name, object.type.toUpperCase(), object.tableType);
           vscode.commands.executeCommand(`vscode-db2i.runEditorStatement`, {
             content,
             qualifier: `statement`,

--- a/src/views/schemaBrowser/statements.ts
+++ b/src/views/schemaBrowser/statements.ts
@@ -243,7 +243,7 @@ export function getMTIStatement(schema: string, table: string = `*ALL`) {
   ].join(` `);
 }
 
-export function getAuthoritiesStatement(schema: string, table: string, objectType: string, tableType: string): string {
+export function getAuthoritiesStatement(schema: string, name: string, objectType: string, tableType: string): string {
   let sql: string = `
     select 
       authorization_name "User profile name", 
@@ -265,8 +265,8 @@ export function getAuthoritiesStatement(schema: string, table: string, objectTyp
       data_execute "Data execute authority", 
       text_description "Description"
     from qsys2.object_privileges
-    where system_object_schema = '${Statement.escapeString(schema)}' 
-      and system_object_name = '${Statement.escapeString(table)}'
+    where object_schema = '${Statement.escapeString(schema)}' 
+      and object_name = '${Statement.escapeString(name)}'
   `;
   if (objectType === 'TABLE' && tableType != 'T') {
     sql += ` and object_type = '*FILE'`;
@@ -282,7 +282,7 @@ export function getAuthoritiesStatement(schema: string, table: string, objectTyp
   return sql;
 }
 
-export function getObjectLocksStatement(schema: string, table: string, objectType: string, tableType: string): string {
+export function getObjectLocksStatement(schema: string, name: string, objectType: string, tableType: string): string {
   let sql: string = `
       select
         system_table_member "Member",
@@ -304,8 +304,8 @@ export function getObjectLocksStatement(schema: string, table: string, objectTyp
         statement_id "Statement ID", 
         machine_instruction "Instruction"
       from qsys2.object_lock_info
-      where system_object_schema = '${Statement.escapeString(schema)}'
-        and system_object_name = '${Statement.escapeString(table)}'
+      where object_schema = '${Statement.escapeString(schema)}'
+        and object_name = '${Statement.escapeString(name)}'
     `;
   if (objectType === 'TABLE' && tableType != 'T') {
     sql += ` and object_type = '*FILE'`;

--- a/src/views/types/ParmTreeItem.ts
+++ b/src/views/types/ParmTreeItem.ts
@@ -15,7 +15,7 @@ export default class ParmTreeItem extends vscode.TreeItem {
   name: string;
 
   constructor(schema: string, routine: string, data: SQLParm) {
-    super(Statement.prettyName(data.PARAMETER_NAME), vscode.TreeItemCollapsibleState.None);
+    super(Statement.prettyName(data.PARAMETER_NAME || ``), vscode.TreeItemCollapsibleState.None);
 
     this.contextValue = `parameter`;
     this.schema = schema;

--- a/src/views/types/function.ts
+++ b/src/views/types/function.ts
@@ -2,12 +2,10 @@
 import Function from "../../database/callable";
 import ParmTreeItem from "./ParmTreeItem";
 
-export async function getChildren (schema: string, specificName: string): Promise<ParmTreeItem[]> {
+export async function getChildren(schema: string, specificName: string): Promise<ParmTreeItem[]> {
   const signatures = await Function.getSignaturesFor(schema, [specificName]);
   const allParms = signatures.map(signature => signature.parms).flat();
-  const removedDupes = allParms.filter((parm, index) => {
-    return allParms.findIndex(p => p.PARAMETER_NAME === parm.PARAMETER_NAME && p.DATA_TYPE === p.DATA_TYPE) === index;
-  });
+  const removedDupes = allParms.filter((parm, index) => allParms.findIndex(p => p.PARAMETER_NAME === parm.PARAMETER_NAME && p.DATA_TYPE === parm.DATA_TYPE && p.ORDINAL_POSITION === parm.ORDINAL_POSITION) === index);
 
   return removedDupes.map(parm => new ParmTreeItem(schema, specificName, parm));
 }

--- a/src/views/types/procedure.ts
+++ b/src/views/types/procedure.ts
@@ -6,7 +6,7 @@ export async function getChildren(schema: string, specificName: string): Promise
   const signatures = await Procedure.getSignaturesFor(schema, [specificName]);
   const allParms = signatures.map(signature => signature.parms).flat();
   const removedDupes = allParms.filter((parm, index) => {
-    return allParms.findIndex(p => p.PARAMETER_NAME === parm.PARAMETER_NAME && p.DATA_TYPE === p.DATA_TYPE) === index;
+    return allParms.findIndex(p => p.PARAMETER_NAME === parm.PARAMETER_NAME && parm.DATA_TYPE === p.DATA_TYPE && parm.ORDINAL_POSITION === p.ORDINAL_POSITION) === index;
   });
 
   return removedDupes.map(parm => new ParmTreeItem(schema, specificName, parm));


### PR DESCRIPTION
This PR fixes two minor issues in the Schema Browser:
- The `Get locks` and `Get authorities` actions could not return any result for objects other than tables. Using the object/schema names instead of the system's fixes the issue.
- Functions with anonymous parameters could not be expanded (it would throw an error. For example, this kind of function:
  ```sql
  CREATE or replace FUNCTION SJULLIAND.ANONYMOUS_PARMS ( 
	INTEGER, INTEGER, INTEGER ) 
	RETURNS SMALLINT CAST FROM CHAR(1)   
	LANGUAGE RPGLE 
	SPECIFIC SJULLIAN.ANYMSPARMS
	NOT DETERMINISTIC 
	NO SQL 
	RETURNS NULL ON NULL INPUT 
	NO EXTERNAL ACTION 
	ALLOW PARALLEL 
	EXTERNAL NAME MYSRVPGM(MYPROC) 
	PARAMETER STYLE GENERAL ;
  ```
  
  <img width="285" height="118" alt="image" src="https://github.com/user-attachments/assets/77a90927-7334-48e3-9d2d-8f4ede7fb303" />

- The code was cleaned up a bit for clarity (use Maps instead of Records, marked fields as readonly
- Delete, Rename, Get Locks and Get Authorities were added to the `Logical` items.