### PR TITLE
Added Clear Results button and action

### DIFF
--- a/package.json
+++ b/package.json
@@ -685,6 +685,13 @@
         "icon": "$(gear)"
       },
       {
+        "command": "vscode-db2i.resultset.clear",
+        "title": "Clear Results",
+        "category": "Db2 for i",
+        "icon": "$(clear-all)",
+        "enablement": "vscode-db2i:canClear"
+      },
+      {
         "command": "vscode-db2i.dove.close",
         "title": "Close",
         "category": "Db2 for i",
@@ -1188,7 +1195,12 @@
         },
         {
           "command": "vscode-db2i.resultset.settings",
-          "group": "navigation",
+          "group": "navigation@10",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.clear",
+          "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         },
         {

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -125,6 +125,13 @@
         "title": "Settings",
         "category": "Db2 for i",
         "icon": "$(gear)"
+      },
+      {
+        "command": "vscode-db2i.resultset.clear",
+        "title": "Clear Results",
+        "category": "Db2 for i",
+        "icon": "$(clear-all)",
+        "enablement": "vscode-db2i:canClear"
       }
     ],
     "submenus": [
@@ -198,7 +205,12 @@
       "view/title": [
         {
           "command": "vscode-db2i.resultset.settings",
-          "group": "navigation",
+          "group": "navigation@10",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.clear",
+          "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         }
       ]

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -95,6 +95,8 @@ export function initialise(context: vscode.ExtensionContext) {
       vscode.commands.executeCommand('workbench.action.openSettings', 'vscode-db2i.resultsets');
     }),
 
+    vscode.commands.registerCommand(`vscode-db2i.resultset.clear`,  () => resultSetProvider.clear()),
+
     vscode.workspace.onDidChangeConfiguration(e => {
       // If the result set column headings setting has changed, update the header of the current result set
       if (e.affectsConfiguration('vscode-db2i.resultsets.columnHeadings')) {

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -1,17 +1,17 @@
-import { window, CancellationToken, WebviewPanel, WebviewView, WebviewViewProvider, WebviewViewResolveContext, commands } from "vscode";
+import { CancellationToken, WebviewPanel, WebviewView, WebviewViewProvider, WebviewViewResolveContext, commands, window } from "vscode";
 
+import { QueryResult } from "@ibm/mapepire-js";
+import { Query } from "@ibm/mapepire-js/dist/src/query";
 import { setCancelButtonVisibility } from ".";
 import { JobManager } from "../../config";
-import { updateStatusBar } from "../jobManager/statusBar";
 import Configuration from "../../configuration";
-import * as html from "./html";
-import { Query } from "@ibm/mapepire-js/dist/src/query";
-import { ObjectRef } from "../../language/sql/types";
-import Table from "../../database/table";
 import Statement from "../../database/statement";
+import Table from "../../database/table";
+import { ObjectRef } from "../../language/sql/types";
 import { TableColumn } from "../../types";
+import { updateStatusBar } from "../jobManager/statusBar";
 import { statementDone } from "./editorUi";
-import { QueryResult } from "@ibm/mapepire-js";
+import * as html from "./html";
 
 export type SqlParameter = string | number;
 
@@ -99,6 +99,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
         default:
           if (message.query) {
+            let canClear = false;
             if (this.currentQuery) {
               // If we get a request for a new query, then we need to close the old one
               if (this.currentQuery.getId() === undefined || this.currentQuery.getId() !== message.queryId) {
@@ -146,6 +147,8 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                   isDone: queryResults.is_done,
                   executionTime
                 });
+
+                canClear = true;
               }
 
             } catch (e) {
@@ -160,6 +163,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
             setCancelButtonVisibility(false);
             updateStatusBar();
+            commands.executeCommand(`setContext`, `vscode-db2i:canClear`, canClear);
           }
           break;
       }
@@ -310,6 +314,11 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
     this.loadingState = false;
     // TODO: pretty error
     this._view.webview.html = `<p>${error}</p>`;
+  }
+
+  clear(){
+    this._view.webview.html = ``;
+    commands.executeCommand(`setContext`, `vscode-db2i:canClear`, false);
   }
 }
 


### PR DESCRIPTION
# Description
Resolves #505 

This PR adds a `Clear Results` button in the Result Set view title toolbar.
<img width="107" height="58" alt="image" src="https://github.com/user-attachments/assets/26bdcf7d-3ec8-4fe4-889f-ff9d13a26d38" />

It is also available from the command palette.
<img width="602" height="60" alt="image" src="https://github.com/user-attachments/assets/6bb3653b-e311-4f21-a173-6128eefdf5e0" />

The action/button is only enabled when there are results to clear.

Running this action does what it says on the tin: it clears the view entirely.

# How to test
1. Run a query
2. The Clear Results button must become enabled
3. Click on it: the results should be cleared and the button disabled