### PR TITLE
Fix conflicting `Explain without running` keyboard shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1635,8 +1635,8 @@
       },
       {
         "command": "vscode-db2i.editorExplain.withoutRun",
-        "key": "ctrl+e",
-        "mac": "cmd+e",
+        "key": "ctrl+alt+u",
+        "mac": "cmd+alt+u",
         "when": "editorLangId == sql && resourceExtname != .inb"
       },
       {

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -236,8 +236,8 @@
       },
       {
         "command": "vscode-db2i.editorExplain.withoutRun",
-        "key": "ctrl+e",
-        "mac": "cmd+e",
+        "key": "ctrl+alt+u",
+        "mac": "cmd+alt+u",
         "when": "editorLangId == sql && resourceExtname != .inb"
       }
     ]


### PR DESCRIPTION
### Changes

This PR changes the `Explain without running` keyboard shortcut to `ctrl+alt+u` / `cmd+alt+u` because the current `ctrl+e` / `cmd+e` conflicts with Code4i's `Run Action` command which is more commonly used.

Fixes #503

<img width="951" height="611" alt="image" src="https://github.com/user-attachments/assets/aa44d9e1-929f-4cc0-b782-e15f92ebb669" />

### How to Test
1. Use `ctrl+e` to verify Code4i's `Run Action` works
2. Use `ctrl+alt+u` to verify `Explain without running` works