### PR TITLE
Fix library list not set on any SQL jobs

### DIFF
--- a/src/views/jobManager/ConfigManager.ts
+++ b/src/views/jobManager/ConfigManager.ts
@@ -166,8 +166,16 @@ export class ConfigManager {
     return Configuration.set(`jobConfigs`, configs);
   };
 
+  private static getSavedDefaultJobConfig() {
+    const configs = Configuration.get<JobConfigs>(`jobManager.defaultJobConfig`); // Returns a proxy
+    if (configs) {
+      return Object.assign({}, configs);
+    }
+  }
+
   static getDefaultConfig(): JDBCOptions {
-    const defaultJobConfig = Configuration.get<JDBCOptions>(`jobManager.defaultJobConfig`) || {
+    const savedDefaultJobConfig = ConfigManager.getSavedDefaultJobConfig();
+    const defaultJobConfig: JDBCOptions = savedDefaultJobConfig || {
       "naming": "system",
       "full open": false,
       "transaction isolation": "none",


### PR DESCRIPTION
### Changes

Previously when retrieving the `jobManager.defaultJobConfig` configurations from VS Code, we get a proxy object which causes issues when we later call `Object.keys(this.options)` when connecting to an SQL job as arrays like `libraries` are lost (I assume it is not treated as enumerable?). This PR creates a copy of the proxy to give us a regular JS object. We do this exact same thing for other retrieved configs in `ConfigManager.ts`.

Fixes https://github.com/codefori/vscode-db2i/issues/503

### How to Test
1. Create an SQL job.
2. Create an SQL file.
3. Run `SELECT * FROM QSYS2.LIBRARY_LIST_INFO` and verify library list matches what is set in JDBC options
4. Change library list and repeat step 2.
