### PR TITLE
Add button to retrieve more/all rows, and refresh result

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,9 @@
             "type": "integer",
             "order": 0,
             "description": "Number of rows to retrieve at a time",
-            "default": 100
+            "default": 100,
+            "minimum": 1,
+            "maximum": 2147483647
           },
           "vscode-db2i.resultsets.columnHeadings": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -685,6 +685,13 @@
         "icon": "$(gear)"
       },
       {
+        "command": "vscode-db2i.resultset.retrieveMoreRows",
+        "title": "Retrieve More Rows",
+        "category": "Db2 for i",
+        "icon": "$(git-stash)",
+        "enablement": "vscode-db2i:canRetrieveMoreRows"
+      },
+      {
         "command": "vscode-db2i.resultset.clear",
         "title": "Clear Results",
         "category": "Db2 for i",
@@ -1194,13 +1201,18 @@
           "when": "view == schemaBrowser"
         },
         {
-          "command": "vscode-db2i.resultset.settings",
-          "group": "navigation@10",
+          "command": "vscode-db2i.resultset.retrieveMoreRows",
+          "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         },
         {
           "command": "vscode-db2i.resultset.clear",
-          "group": "navigation@01",
+          "group": "navigation@02",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.settings",
+          "group": "navigation@10",
           "when": "view == vscode-db2i.resultset"
         },
         {

--- a/package.json
+++ b/package.json
@@ -231,9 +231,15 @@
         "id": "vscode-db2i.resultsets",
         "title": "Viewing Data",
         "properties": {
+          "vscode-db2i.resultsets.rowsToFetch": {
+            "type": "integer",
+            "order": 0,
+            "description": "Number of rows to retrieve at a time",
+            "default": 100
+          },
           "vscode-db2i.resultsets.columnHeadings": {
             "type": "string",
-            "order": 0,
+            "order": 1,
             "description": "Descriptor to use for column headings when viewing data",
             "default": "Name",
             "enum": [
@@ -248,11 +254,13 @@
           },
           "vscode-db2i.collapsedResultSet": {
             "type": "boolean",
+            "order": 2,
             "description": "Make larger cells collapsed by default",
             "default": false
           },
           "vscode-db2i.resultsets.outputDecorations": {
             "type": "boolean",
+            "order": 3,
             "description": "Show INOUT and OUT parameters inside the editor",
             "default": true
           }

--- a/package.json
+++ b/package.json
@@ -688,7 +688,12 @@
         "command": "vscode-db2i.resultset.retrieveMoreRows",
         "title": "Retrieve More Rows",
         "category": "Db2 for i",
-        "icon": "$(git-stash)",
+        "enablement": "vscode-db2i:canRetrieveMoreRows"
+      },
+      {
+        "command": "vscode-db2i.resultset.retrieveAllRows",
+        "title": "Retrieve All Rows",
+        "category": "Db2 for i",
         "enablement": "vscode-db2i:canRetrieveMoreRows"
       },
       {
@@ -1208,7 +1213,7 @@
           "when": "view == schemaBrowser"
         },
         {
-          "command": "vscode-db2i.resultset.retrieveMoreRows",
+          "submenu": "vscode-db2i.resultset.retrieve",
           "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         },
@@ -1593,6 +1598,16 @@
           "group": "navigation_notebook@1"
         }
       ],
+      "vscode-db2i.resultset.retrieve": [
+        {
+          "command": "vscode-db2i.resultset.retrieveMoreRows",
+          "group": "navigation@0"
+        },
+        {
+          "command": "vscode-db2i.resultset.retrieveAllRows",
+          "group": "navigation@1"
+        }
+      ],
       "vscode-db2i.jobManager.defaultSettings": [
         {
           "command": "vscode-db2i.jobManager.editDefaultJobProps",
@@ -1626,6 +1641,11 @@
         "icon": "$(notebook-execute)",
         "id": "sql/editor/context",
         "label": "Run SQL statement"
+      },
+      {
+        "id": "vscode-db2i.resultset.retrieve",
+        "label": "Retrieve...",
+        "icon": "$(git-stash)"
       },
       {
         "id": "vscode-db2i.jobManager.defaultSettings",

--- a/package.json
+++ b/package.json
@@ -692,6 +692,13 @@
         "enablement": "vscode-db2i:canRetrieveMoreRows"
       },
       {
+        "command": "vscode-db2i.resultset.refresh",
+        "title": "Refresh",
+        "category": "Db2 for i",
+        "icon": "$(refresh)",
+        "enablement": "vscode-db2i:canRefresh"
+      },
+      {
         "command": "vscode-db2i.resultset.clear",
         "title": "Clear Results",
         "category": "Db2 for i",
@@ -1206,8 +1213,13 @@
           "when": "view == vscode-db2i.resultset"
         },
         {
-          "command": "vscode-db2i.resultset.clear",
+          "command": "vscode-db2i.resultset.refresh",
           "group": "navigation@02",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.clear",
+          "group": "navigation@03",
           "when": "view == vscode-db2i.resultset"
         },
         {

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -127,6 +127,13 @@
         "icon": "$(gear)"
       },
       {
+        "command": "vscode-db2i.resultset.retrieveMoreRows",
+        "title": "Retrieve More Rows",
+        "category": "Db2 for i",
+        "icon": "$(git-stash)",
+        "enablement": "vscode-db2i:canRetrieveMoreRows"
+      },
+      {
         "command": "vscode-db2i.resultset.clear",
         "title": "Clear Results",
         "category": "Db2 for i",
@@ -204,13 +211,18 @@
       ],
       "view/title": [
         {
-          "command": "vscode-db2i.resultset.settings",
-          "group": "navigation@10",
+          "command": "vscode-db2i.resultset.retrieveMoreRows",
+          "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         },
         {
           "command": "vscode-db2i.resultset.clear",
-          "group": "navigation@01",
+          "group": "navigation@02",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.settings",
+          "group": "navigation@10",
           "when": "view == vscode-db2i.resultset"
         }
       ]

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -134,6 +134,13 @@
         "enablement": "vscode-db2i:canRetrieveMoreRows"
       },
       {
+        "command": "vscode-db2i.resultset.refresh",
+        "title": "Refresh",
+        "category": "Db2 for i",
+        "icon": "$(refresh)",
+        "enablement": "vscode-db2i:canRefresh"
+      },
+      {
         "command": "vscode-db2i.resultset.clear",
         "title": "Clear Results",
         "category": "Db2 for i",
@@ -216,8 +223,13 @@
           "when": "view == vscode-db2i.resultset"
         },
         {
-          "command": "vscode-db2i.resultset.clear",
+          "command": "vscode-db2i.resultset.refresh",
           "group": "navigation@02",
+          "when": "view == vscode-db2i.resultset"
+        },
+        {
+          "command": "vscode-db2i.resultset.clear",
+          "group": "navigation@03",
           "when": "view == vscode-db2i.resultset"
         },
         {

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -9,7 +9,9 @@
             "type": "integer",
             "order": 0,
             "description": "Number of rows to retrieve at a time",
-            "default": 100
+            "default": 100,
+            "minimum": 1,
+            "maximum": 2147483647
           },
           "vscode-db2i.resultsets.columnHeadings": {
             "type": "string",

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -5,9 +5,15 @@
         "id": "vscode-db2i.resultsets",
         "title": "Viewing Data",
         "properties": {
+          "vscode-db2i.resultsets.rowsToFetch": {
+            "type": "integer",
+            "order": 0,
+            "description": "Number of rows to retrieve at a time",
+            "default": 100
+          },
           "vscode-db2i.resultsets.columnHeadings": {
             "type": "string",
-            "order": 0,
+            "order": 1,
             "description": "Descriptor to use for column headings when viewing data",
             "default": "Name",
             "enum": [
@@ -22,11 +28,13 @@
           },
           "vscode-db2i.collapsedResultSet": {
             "type": "boolean",
+            "order": 2,
             "description": "Make larger cells collapsed by default",
             "default": false
           },
           "vscode-db2i.resultsets.outputDecorations": {
             "type": "boolean",
+            "order": 3,
             "description": "Show INOUT and OUT parameters inside the editor",
             "default": true
           }

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -130,7 +130,12 @@
         "command": "vscode-db2i.resultset.retrieveMoreRows",
         "title": "Retrieve More Rows",
         "category": "Db2 for i",
-        "icon": "$(git-stash)",
+        "enablement": "vscode-db2i:canRetrieveMoreRows"
+      },
+      {
+        "command": "vscode-db2i.resultset.retrieveAllRows",
+        "title": "Retrieve All Rows",
+        "category": "Db2 for i",
         "enablement": "vscode-db2i:canRetrieveMoreRows"
       },
       {
@@ -153,6 +158,11 @@
         "icon": "$(notebook-execute)",
         "id": "sql/editor/context",
         "label": "Run SQL statement"
+      },
+      {
+        "id": "vscode-db2i.resultset.retrieve",
+        "label": "Retrieve...",
+        "icon": "$(git-stash)"
       }
     ],
     "menus": {
@@ -216,9 +226,19 @@
           "group": "navigation_notebook@1"
         }
       ],
-      "view/title": [
+      "vscode-db2i.resultset.retrieve": [
         {
           "command": "vscode-db2i.resultset.retrieveMoreRows",
+          "group": "navigation@0"
+        },
+        {
+          "command": "vscode-db2i.resultset.retrieveAllRows",
+          "group": "navigation@1"
+        }
+      ],
+      "view/title": [
+        {
+          "submenu": "vscode-db2i.resultset.retrieve",
           "group": "navigation@01",
           "when": "view == vscode-db2i.resultset"
         },

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -359,6 +359,7 @@ export function generateScroller(uiId: string, basicSelect: string, parameters: 
           let totalRows = 0;
           let noMoreRows = false;
           let isFetching = false;
+          let allRows = false;
 
           function isNumeric(str) {
             if (typeof str != "string") return false // we only process strings!  
@@ -427,6 +428,7 @@ export function generateScroller(uiId: string, basicSelect: string, parameters: 
 
                 case 'fetch':
                   // Set loading here....
+                  allRows = data.allRows === true;
                   fetchNextPage();
                   break;
 
@@ -455,7 +457,8 @@ export function generateScroller(uiId: string, basicSelect: string, parameters: 
               query: basicSelect,
               parameters: ${JSON.stringify(parameters)},
               isCL: ${isCL},
-              queryId: myQueryId
+              queryId: myQueryId,
+              allRows: allRows
             });
           }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -95,6 +95,8 @@ export function initialise(context: vscode.ExtensionContext) {
       vscode.commands.executeCommand('workbench.action.openSettings', 'vscode-db2i.resultsets');
     }),
 
+    vscode.commands.registerCommand(`vscode-db2i.resultset.retrieveMoreRows`, () => resultSetProvider.retrieveMoreRows()),
+
     vscode.commands.registerCommand(`vscode-db2i.resultset.clear`, () => resultSetProvider.clear()),
 
     vscode.workspace.onDidChangeConfiguration(e => {

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -97,6 +97,8 @@ export function initialise(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand(`vscode-db2i.resultset.retrieveMoreRows`, () => resultSetProvider.retrieveMoreRows()),
 
+    vscode.commands.registerCommand(`vscode-db2i.resultset.refresh`, async () => await resultSetProvider.refresh()),
+
     vscode.commands.registerCommand(`vscode-db2i.resultset.clear`, () => resultSetProvider.clear()),
 
     vscode.workspace.onDidChangeConfiguration(e => {
@@ -259,6 +261,8 @@ async function runHandler(options?: StatementInfo) {
   if (options === undefined || options.viewColumn === undefined) {
     await resultSetProvider.ensureActivation();
   }
+
+  resultSetProvider.resetContext();
 
   // Options here can be a vscode.Uri when called from editor context.
   // But that isn't valid here.

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -97,6 +97,8 @@ export function initialise(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand(`vscode-db2i.resultset.retrieveMoreRows`, () => resultSetProvider.retrieveMoreRows()),
 
+    vscode.commands.registerCommand(`vscode-db2i.resultset.retrieveAllRows`, () => resultSetProvider.retrieveMoreRows(true)),
+
     vscode.commands.registerCommand(`vscode-db2i.resultset.refresh`, async () => await resultSetProvider.refresh()),
 
     vscode.commands.registerCommand(`vscode-db2i.resultset.clear`, () => resultSetProvider.clear()),

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -46,12 +46,13 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
     }
   }
 
-  retrieveMoreRows() {
+  retrieveMoreRows(allRows?: boolean) {
     if (this._view) {
       const queryId = this.currentQuery?.getId();
       this._view.webview.postMessage({
         command: `fetch`,
-        queryId: queryId
+        queryId: queryId,
+        allRows: allRows === true
       });
     }
   }
@@ -147,7 +148,10 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 let executionTime: number | undefined;
 
                 if (this.currentQuery.getState() == "RUN_MORE_DATA_AVAILABLE") {
-                  queryResults = await this.currentQuery.fetchMore();
+                  // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
+                  // int. This is the largest number available without overflow (Integer.MAX_VALUE)
+                  const rowsToFetch = message.allRows === true ? 2147483647 : undefined;
+                  queryResults = await this.currentQuery.fetchMore(rowsToFetch);
                 }
                 else {
                   startTime = performance.now();

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -29,6 +29,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
   _view: WebviewView | WebviewPanel;
   loadingState: boolean;
   currentQuery: Query<any>;
+  lastScrollerOptions: ScrollerOptions | undefined;
   constructor() {
     this._view = undefined;
     this.loadingState = false;
@@ -52,6 +53,18 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
         command: `fetch`,
         queryId: queryId
       });
+    }
+  }
+
+  async refresh() {
+    if (this.lastScrollerOptions) {
+      // Close the current query if it exists
+      if (this.currentQuery) {
+        await this.currentQuery.close();
+        this.currentQuery = undefined;
+      }
+      // Re-run the query with the same options
+      await this.setScrolling(this.lastScrollerOptions);
     }
   }
 
@@ -111,6 +124,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
           if (message.query) {
             let canClear = false;
             let canRetrieveMoreRows = false;
+            let canRefresh = false;
             if (this.currentQuery) {
               // If we get a request for a new query, then we need to close the old one
               if (this.currentQuery.getId() === undefined || this.currentQuery.getId() !== message.queryId) {
@@ -161,6 +175,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
                 canClear = true;
                 canRetrieveMoreRows = !queryResults.is_done;
+                canRefresh = true;
               }
 
             } catch (e) {
@@ -177,6 +192,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
             updateStatusBar();
             commands.executeCommand(`setContext`, `vscode-db2i:canClear`, canClear);
             commands.executeCommand(`setContext`, `vscode-db2i:canRetrieveMoreRows`, canRetrieveMoreRows);
+            commands.executeCommand(`setContext`, `vscode-db2i:canRefresh`, canRefresh);
           }
           break;
       }
@@ -231,6 +247,8 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
   }
 
   async setScrolling(options: ScrollerOptions) {
+    this.lastScrollerOptions = { ...options };
+    
     this.loadingState = false;
     await this.focus();
 
@@ -331,8 +349,13 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
   clear(){
     this._view.webview.html = ``;
+    this.resetContext();
+  }
+
+  resetContext() {
     commands.executeCommand(`setContext`, `vscode-db2i:canClear`, false);
     commands.executeCommand(`setContext`, `vscode-db2i:canRetrieveMoreRows`, false);
+    commands.executeCommand(`setContext`, `vscode-db2i:canRefresh`, false);
   }
 }
 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -147,15 +147,16 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 let endTime = 0;
                 let executionTime: number | undefined;
 
+                let rowsToFetch = Configuration.get<number>('resultsets.rowsToFetch') || 100;
                 if (this.currentQuery.getState() == "RUN_MORE_DATA_AVAILABLE") {
                   // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
                   // int. This is the largest number available without overflow (Integer.MAX_VALUE)
-                  const rowsToFetch = message.allRows === true ? 2147483647 : undefined;
+                  rowsToFetch = message.allRows === true ? 2147483647 : rowsToFetch;
                   queryResults = await this.currentQuery.fetchMore(rowsToFetch);
                 }
                 else {
                   startTime = performance.now();
-                  queryResults = await this.currentQuery.execute();
+                  queryResults = await this.currentQuery.execute(rowsToFetch);
                   endTime = performance.now();
                   executionTime = (endTime - startTime);
 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -45,6 +45,16 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
     }
   }
 
+  retrieveMoreRows() {
+    if (this._view) {
+      const queryId = this.currentQuery?.getId();
+      this._view.webview.postMessage({
+        command: `fetch`,
+        queryId: queryId
+      });
+    }
+  }
+
   resolveWebviewView(webviewView: WebviewView | WebviewPanel, context?: WebviewViewResolveContext, _token?: CancellationToken) {
     this._view = webviewView;
 
@@ -100,6 +110,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
         default:
           if (message.query) {
             let canClear = false;
+            let canRetrieveMoreRows = false;
             if (this.currentQuery) {
               // If we get a request for a new query, then we need to close the old one
               if (this.currentQuery.getId() === undefined || this.currentQuery.getId() !== message.queryId) {
@@ -149,6 +160,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 });
 
                 canClear = true;
+                canRetrieveMoreRows = !queryResults.is_done;
               }
 
             } catch (e) {
@@ -164,6 +176,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
             setCancelButtonVisibility(false);
             updateStatusBar();
             commands.executeCommand(`setContext`, `vscode-db2i:canClear`, canClear);
+            commands.executeCommand(`setContext`, `vscode-db2i:canRetrieveMoreRows`, canRetrieveMoreRows);
           }
           break;
       }
@@ -319,6 +332,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
   clear(){
     this._view.webview.html = ``;
     commands.executeCommand(`setContext`, `vscode-db2i:canClear`, false);
+    commands.executeCommand(`setContext`, `vscode-db2i:canRetrieveMoreRows`, false);
   }
 }
 


### PR DESCRIPTION
### Changes

As of right now, users have to scroll to the bottom of the results panel to load more results. Several users have reported that this has been an issue. Although I haven't found an exact fix to the scrolling issue, I was able to reproduce the issue on my end by zooming in (quite a lot!). As a work around and nice feature, I thought it would make sense to add a button to `Retrieve More Rows`. The button should only be enabled when there are more rows to fetch.

Fixes #509
Fixes #470
Fixes #341
Fixes #287

<img width="3170" height="1320" alt="image" src="https://github.com/user-attachments/assets/078f2b40-b0cc-4039-ba75-3a780c60755b" />

### How To Test

1. Run a query with more than 100 rows and verify the new button works in fetching more rows.
2. Run a query with less than 100 rows (or repeat step 1 until all rows are retrieved) and verify the new button is disabled.
3. Run a query, use the `Clear Results` (button beside it) and verify the new button is disabled.