### PR TITLE
Bump mapepire to `2.3.5`

### DIFF
--- a/src/connection/SCVersion.ts
+++ b/src/connection/SCVersion.ts
@@ -1,4 +1,4 @@
 
-export const VERSION = `2.3.4`;
+export const VERSION = `2.3.5`;
 export const SERVER_VERSION_TAG = `v${VERSION}`;
 export const SERVER_VERSION_FILE = `mapepire-server-${VERSION}.jar`;


### PR DESCRIPTION
### Changes
- This PR bumps the mapepire server version which is pulled in. To test the fix in this release, enable `Translate Binary` in your job's JDBC options and use visual explain