### PR TITLE
Fix syntax errors impacting parsing of subsequent statements

### DIFF
--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -59,6 +59,7 @@ export default class Document {
           this.addStatement(statementTokens);
 
           statementStart = i + 1;
+          bracketDepth = 0;
           break;
 
         case `statementType`:

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -1404,6 +1404,35 @@ parserScenarios(`PL body tests`, ({newDoc}) => {
     expect(blockParent.parentRef.object.name).toBe(`MEDIAN_RESULT_SET`);
   });
 
+  test(`CREATE PROCEDURE after syntax error`, () => {
+    const lines = [
+      `-- SELECT with syntax error (extra closing brackets)`,
+      `select * from table(qsys2.ifs_object_statistics('/home/scottf/'))));`,
+      ``,
+      `--CREATE parsing should not be impacted`,
+      `create or replace procedure coolstuff.proc1()`,
+      `begin`,
+      `    declare v1 integer;`,
+      `    declare v2 integer;`,
+      `    select 1+1, 2+2, 3+3 into v1, v2 from sysibm.sysdummy1;`,
+      `end;`
+    ].join(`\r\n`);
+
+    const document = newDoc(lines);
+    const statements = document.statements;
+
+    expect(statements.length).toBe(6);
+    expect(statements[0].tokens.length).toBe(14);
+    expect(statements[1].tokens.length).toBe(10);
+    expect(statements[2].tokens.length).toBe(3);
+    expect(statements[3].tokens.length).toBe(3);
+    expect(statements[4].tokens.length).toBe(20);
+    expect(statements[5].tokens.length).toBe(1);
+
+    const groups = document.getStatementGroups();
+    expect(groups.length).toBe(2);
+  });
+
   test(`WITH: no explicit columns`, () => {
     const lines = [
       `with Temp01 as`,


### PR DESCRIPTION
### Changes
Although syntax errors can definitely impact parsing, there are cases where we can gracefully handle parsing of subsequent lines especially when a user has a semi-colon.

#### Previously
If there was a line with a syntax error (such as extra brackets in the example below), it flagged the syntax errors. However, subsequent lines were not being parsed correctly.

<img width="2354" height="633" alt="image" src="https://github.com/user-attachments/assets/31ebfef8-ebc6-4270-be81-420ce9d93c5b" />

We also wouldn't be able to run the next statement correctly to create the procedure as the statement range is incorrectly parsed:
<img width="1771" height="745" alt="image" src="https://github.com/user-attachments/assets/f3903807-11b5-4ec9-852f-74d6bd37f5b7" />

#### Now
The bug in parsing was that the `bracketDepth` was not being reset as there is a bracket mismatch. However, since the user has a semi-colon, we can gracefully treat that as the end of the statement and thus reset the count to move onto parsing the next statement as normal.

We now only get syntax errors for the first line as expected and can run the create procedure statement.