### PR TITLE
feat: Add "Copy as SQL List" context menu commands for SQL editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,16 @@
               "Java 17",
               "Java 21"
             ]
+          },
+          "vscode-db2i.delimitedList.quoteNumbers": {
+            "type": "boolean",
+            "description": "Quote numeric values when copying a selection as a SQL list",
+            "default": true
+          },
+          "vscode-db2i.delimitedList.wrapInParentheses": {
+            "type": "boolean",
+            "description": "Wrap the SQL list in parentheses when using 'Copy as SQL List' (instant copy)",
+            "default": false
           }
         }
       },
@@ -540,6 +550,16 @@
       {
         "command": "vscode-db2i.importDataContextMenu",
         "title": "Generate Insert from File",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.copyAsDelimitedList",
+        "title": "Copy as SQL List",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.copyAsDelimitedListPrompt",
+        "title": "Copy as SQL List (Prompt Format)",
         "category": "Db2 for i"
       },
       {
@@ -1033,6 +1053,14 @@
           "when": "false"
         },
         {
+          "command": "vscode-db2i.copyAsDelimitedList",
+          "when": "editorLangId == sql && editorHasSelection"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedListPrompt",
+          "when": "editorLangId == sql && editorHasSelection"
+        },
+        {
           "command": "vscode-db2i.filterDatabaseObjectTypes",
           "when": "never"
         },
@@ -1204,6 +1232,16 @@
         {
           "command": "vscode-db2i.importDataContextMenu",
           "group": "sql@3"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedList",
+          "group": "sql@4",
+          "when": "editorLangId == sql && editorHasSelection"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedListPrompt",
+          "group": "sql@5",
+          "when": "editorLangId == sql && editorHasSelection"
         }
       ],
       "view/title": [

--- a/src/contributes.json
+++ b/src/contributes.json
@@ -38,6 +38,16 @@
               "Java 17",
               "Java 21"
             ]
+          },
+          "vscode-db2i.delimitedList.quoteNumbers": {
+            "type": "boolean",
+            "description": "Quote numeric values when copying a selection as a SQL list",
+            "default": true
+          },
+          "vscode-db2i.delimitedList.wrapInParentheses": {
+            "type": "boolean",
+            "description": "Wrap the SQL list in parentheses when using 'Copy as SQL List' (instant copy)",
+            "default": false
           }
         }
       },
@@ -137,6 +147,16 @@
         "command": "vscode-db2i.importDataContextMenu",
         "title": "Generate Insert from File",
         "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.copyAsDelimitedList",
+        "title": "Copy as SQL List",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.copyAsDelimitedListPrompt",
+        "title": "Copy as SQL List (Prompt Format)",
+        "category": "Db2 for i"
       }
     ],
     "menus": {
@@ -148,6 +168,14 @@
         {
           "command": "vscode-db2i.importDataContextMenu",
           "when": "false"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedList",
+          "when": "editorLangId == sql && editorHasSelection"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedListPrompt",
+          "when": "editorLangId == sql && editorHasSelection"
         }
       ],
       "editor/context": [
@@ -169,6 +197,16 @@
         {
           "command": "vscode-db2i.importDataContextMenu",
           "group": "sql@3"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedList",
+          "group": "sql@4",
+          "when": "editorLangId == sql && editorHasSelection"
+        },
+        {
+          "command": "vscode-db2i.copyAsDelimitedListPrompt",
+          "group": "sql@5",
+          "when": "editorLangId == sql && editorHasSelection"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import SchemaBrowser from "./views/schemaBrowser";
 
 import * as JSONServices from "./language/json";
+import * as ClipboardServices from "./language/clipboard";
 import * as resultsProvider from "./views/results";
 
 import { JDBCOptions } from "@ibm/mapepire-js/dist/src/types";
@@ -73,6 +74,7 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   );
 
   JSONServices.initialise(context);
+  ClipboardServices.initialise(context);
   resultsProvider.initialise(context);
 
   initConfig(context);

--- a/src/language/clipboard.ts
+++ b/src/language/clipboard.ts
@@ -1,0 +1,118 @@
+import * as vscode from "vscode";
+import Configuration from "../configuration";
+
+const NUMERIC_RE = /^\d+(\.\d+)?$/;
+const LARGE_SELECTION_THRESHOLD = 256; // Just for safety
+
+function getLines(selectedText: string): string[] {
+  return selectedText
+    .split(/\r?\n/)
+    .map((line: string) => line.trim())
+    .filter((line: string) => line.length > 0);
+}
+
+function quoteLine(line: string): string {
+  return `'${line.replace(/'/g, `''`)}'`;
+}
+
+function buildList(lines: string[], quoteNumbers: boolean, wrap: boolean): string {
+  const values = lines.map((line: string) =>
+    !quoteNumbers && NUMERIC_RE.test(line) ? line : quoteLine(line)
+  );
+  const csv = values.join(`, `);
+  return wrap ? `(${csv})` : csv;
+}
+
+async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    await vscode.env.clipboard.writeText(text);
+    return true;
+  } catch (e) {
+    vscode.window.showErrorMessage(`Failed to write to clipboard: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}
+
+async function confirmLargeSelection(count: number): Promise<boolean> {
+  if (count <= LARGE_SELECTION_THRESHOLD) return true;
+  const answer = await vscode.window.showWarningMessage(
+    `Your selection contains ${count} values. Continue copying to clipboard?`,
+    { modal: true },
+    `Continue`
+  );
+  return answer === `Continue`;
+}
+
+export function initialise(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+
+    // ── Instant copy using current settings ──────────────────────────────────
+    vscode.commands.registerCommand(`vscode-db2i.copyAsDelimitedList`, async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) return;
+
+      const selectedText = editor.document.getText(editor.selection);
+      const lines = getLines(selectedText);
+
+      if (lines.length === 0) {
+        vscode.window.showErrorMessage(`No text selected.`);
+        return;
+      }
+
+      if (!await confirmLargeSelection(lines.length)) return;
+
+      const quoteNumbers = Configuration.get<boolean>(`delimitedList.quoteNumbers`) ?? true;
+      const wrapInParens = Configuration.get<boolean>(`delimitedList.wrapInParentheses`) ?? false;
+
+      const result = buildList(lines, quoteNumbers, wrapInParens);
+      if (await writeToClipboard(result)) {
+        vscode.window.showInformationMessage(`SQL list copied to clipboard.`);
+      }
+    }),
+
+    // ── Prompted copy with format options ────────────────────────────────────
+    vscode.commands.registerCommand(`vscode-db2i.copyAsDelimitedListPrompt`, async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) return;
+
+      const selectedText = editor.document.getText(editor.selection);
+      const lines = getLines(selectedText);
+
+      if (lines.length === 0) {
+        vscode.window.showErrorMessage(`No text selected.`);
+        return;
+      }
+
+      if (!await confirmLargeSelection(lines.length)) return;
+
+      const hasNumbers = lines.some((line: string) => NUMERIC_RE.test(line));
+
+      const listQuoted       = buildList(lines, true, false);
+      const listQuotedParens = buildList(lines, true, true);
+
+      type QuickPickItem = { label: string; description: string; value: string };
+      const options: QuickPickItem[] = [
+        { label: `Copy as list`, description: listQuoted, value: listQuoted },
+      ];
+
+      if (hasNumbers) {
+        const listUnquoted       = buildList(lines, false, false);
+        const listUnquotedParens = buildList(lines, false, true);
+        options.push(
+          { label: `Copy as list (numbers unquoted)`, description: listUnquoted, value: listUnquoted },
+          { label: `Copy wrapped in parentheses`, description: listQuotedParens, value: listQuotedParens },
+          { label: `Copy wrapped in parentheses (numbers unquoted)`, description: listUnquotedParens, value: listUnquotedParens }
+        );
+      } else {
+        options.push(
+          { label: `Copy wrapped in parentheses`, description: listQuotedParens, value: listQuotedParens }
+        );
+      }
+
+      const choice = await vscode.window.showQuickPick(options, { title: `Copy as SQL List` });
+      if (choice && await writeToClipboard(choice.value)) {
+        vscode.window.showInformationMessage(`SQL list copied to clipboard.`);
+      }
+    })
+  );
+}


### PR DESCRIPTION
## Summary

Adds two new right-click context menu commands to SQL editors, available whenever text is selected. This addresses a feature request from the IBM i OSS community where users wanted a quick way to convert a plain newline-separated list of values (e.g. product codes, order numbers) into a SQL-friendly quoted, comma-separated list for use in `IN` clauses and similar constructs — without leaving VS Code to use another tool like dBeaver.

> Community request: https://chat.ibmioss.org/#narrow/channel/8-vscode/topic/Seb's.20Extension.20Example.20Part.20deux/with/4188

---

## New Commands

### `Db2 for i: Copy as SQL List`
Instantly copies the selected newline-separated values to the clipboard using the user's current settings. No prompt — fast path for users who code quickly and want a single keystroke-style experience.

### `Db2 for i: Copy as SQL List (Prompt Format)`
Shows a QuickPick menu with format options before copying. When the selection contains numeric values, additional unquoted variants are offered:

| Option | Example output |
|---|---|
| Copy as list | `'S10_1678', 'S10_1949', 'S10_2016'` |
| Copy as list (numbers unquoted) | `'ABC', 123, 'DEF'` |
| Copy wrapped in parentheses | `('S10_1678', 'S10_1949', 'S10_2016')` |
| Copy wrapped in parentheses (numbers unquoted) | `('ABC', 123, 'DEF')` |

Both commands only appear in the context menu and command palette when a SQL file has an active text selection (`editorLangId == sql && editorHasSelection`).

---

## New Settings

| Setting | Type | Default | Description |
|---|---|---|---|
| `vscode-db2i.delimitedList.quoteNumbers` | boolean | `true` | Whether the instant-copy command quotes numeric values |
| `vscode-db2i.delimitedList.wrapInParentheses` | boolean | `false` | Whether the instant-copy command wraps the list in parentheses |

---

## Implementation Notes

- **SQL-safe quoting**: Internal single quotes are escaped as `''` (e.g. `O'Brien` → `'O''Brien'`)
- **Blank line filtering**: Empty/whitespace-only lines in the selection are silently ignored
- **Large selection guard**: A modal confirmation is shown if more than 256 values are selected
- **Clipboard error handling**: `clipboard.writeText()` failures surface a descriptive error message rather than failing silently
- New file: `src/language/clipboard.ts` — follows the same `initialise(context)` pattern as `src/language/json.ts`