### PR TITLE
Fixed CL Notebook output for Code for IBM i v3

### DIFF
--- a/src/notebooks/Controller.ts
+++ b/src/notebooks/Controller.ts
@@ -5,8 +5,8 @@ import * as mdTable from 'json-to-markdown-table';
 
 import { getInstance } from '../base';
 import { JobManager } from '../config';
-import { ChartJsType, chartJsTypes, generateChartHTMLCell } from './logic/chartJs';
 import { ChartDetail, generateChart } from './logic/chart';
+import { ChartJsType, chartJsTypes, generateChartHTMLCell } from './logic/chartJs';
 import { getStatementDetail } from './logic/statement';
 
 export class IBMiController {
@@ -82,22 +82,21 @@ export class IBMiController {
               ({ chartDetail, content } = getStatementDetail(content, eol));
 
               // Execute the query
-              const query = selected.job.query(content);
+              const query = selected.job.query<any>(content);
               const results = await query.execute(1000);
 
               const table = results.data;
-              const columnNames = results.metadata.columns.map(c => c.name);
+              const columnNames = results.metadata.columns?.map(c => c.name);
 
               if (table === undefined && results.success && !results.has_results) {
                 items.push(vscode.NotebookCellOutputItem.text(`Statement executed successfully. ${results.update_count ? `${results.update_count} rows affected.` : ``}`, `text/markdown`));
                 break;
               }
 
-              if (table.length > 0) {
+              if (table.length && columnNames) {
                 // Add `-` for blanks.
                 table.forEach(row => {
                   columnNames.forEach(key => {
-                    //@ts-ignore
                     if (row[key] === null) { row[key] = `-`; }
                   });
                 });
@@ -125,15 +124,18 @@ export class IBMiController {
               items.push(vscode.NotebookCellOutputItem.stderr(`No job selected in SQL Job Manager.`));
             }
           } catch (e) {
-            items.push(vscode.NotebookCellOutputItem.stderr(e.message));
+            items.push(vscode.NotebookCellOutputItem.stderr(e instanceof Error ? e.message : String(e)));
           }
           break;
 
         case `cl`:
           try {
+
             const command = await connection.runCommand({
               command: cell.document.getText(),
-              environment: `ile`
+              environment: `ile`,
+              //@ts-ignore (remove comment when Code for i v3 is released)
+              getSpooledFiles: true
             });
 
             if (command.stdout) {
@@ -154,7 +156,7 @@ export class IBMiController {
           } catch (e) {
             items.push(
               vscode.NotebookCellOutputItem.stderr(`Failed to run command. Are you connected?`),
-              vscode.NotebookCellOutputItem.stderr(e.message)
+              vscode.NotebookCellOutputItem.stderr(e instanceof Error ? e.message : String(e))
             );
           }
           break;

--- a/src/notebooks/IBMiSerializer.ts
+++ b/src/notebooks/IBMiSerializer.ts
@@ -1,17 +1,15 @@
-import * as vscode from 'vscode';
 import { TextDecoder, TextEncoder } from 'util';
+import * as vscode from 'vscode';
 import { IBMiController } from './Controller';
-import { notebookFromSqlUri } from './logic/openAsNotebook';
 import { Cell, CodeCell, MarkdownCell, Notebook, Output } from './jupyter';
 import { exportNotebookAsHtml } from './logic/export';
+import { notebookFromSqlUri } from './logic/openAsNotebook';
 
 interface RawNotebookCell {
   language: string;
   value: string;
   kind: vscode.NotebookCellKind;
 }
-
-let newNotebookCount = 1;
 
 export function notebookInit() {
   const openBlankNotebook = vscode.commands.registerCommand(`vscode-db2i.notebook.open`, () => {
@@ -40,7 +38,7 @@ export class IBMiSerializer implements vscode.NotebookSerializer {
   ): Promise<vscode.NotebookData> {
     let contents = new TextDecoder().decode(content);
 
-    let asNb: Notebook;
+    let asNb: Notebook | undefined;
     try {
       asNb = <Notebook>JSON.parse(contents);
     } catch {
@@ -80,8 +78,9 @@ export class IBMiSerializer implements vscode.NotebookSerializer {
     
                 return new vscode.NotebookCellOutput(items);
             }
-
-          });
+            return new vscode.NotebookCellOutput([]);
+          })
+          .filter(output => output.items.length);
         }
         
         return newCell;
@@ -118,7 +117,7 @@ export class IBMiSerializer implements vscode.NotebookSerializer {
 }
 
 function nbCellToJupyterCell(cell: vscode.NotebookCellData): Cell {
-  if (cell.kind === vscode.NotebookCellKind.Code) {
+  if (cell.kind === vscode.NotebookCellKind.Code && cell.outputs) {
     const codeBase: CodeCell = {
       cell_type: `code`,
       execution_count: null,


### PR DESCRIPTION
Code for IBM i v3 uses Mapepire to run CL commands and an additionnal property must be used when invoking `runCommand`: the `getSpooledFiles` must be `true` to retrieve the actual output of the command (that goes into a spooled file now).

The change is compatible with version 2 of Code for i - the PR is meant to fix this issue for those using the pre-release version of Code for i.

It also fixes a few TypeScript issues in the Notebooks classes.