### PR TITLE
Fix retrieval of SQL syntax checker components

### DIFF
--- a/src/connection/syntaxChecker/index.ts
+++ b/src/connection/syntaxChecker/index.ts
@@ -53,7 +53,7 @@ export class SQLStatementChecker implements IBMiComponent {
     return this.library;
   }
 
-  static get(): SQLStatementChecker|undefined {
+  static async get(): Promise<SQLStatementChecker|undefined> {
     return getInstance()?.getConnection()?.getComponent<SQLStatementChecker>(SQLStatementChecker.ID);
   }
 

--- a/src/language/providers/problemProvider.ts
+++ b/src/language/providers/problemProvider.ts
@@ -51,10 +51,10 @@ function shouldShowWarnings() {
 const CHECKER_AVAILABLE_CONTEXT = `vscode-db2i.syntax.checkerAvailable`;
 const CHECKER_RUNNING_CONTEXT = `vscode-db2i.syntax.checkerRunning`;
 
-const checkerAvailable = () => (SQLStatementChecker.get() !== undefined);
+const checkerAvailable = async () => (await SQLStatementChecker.get() !== undefined);
 
-export function setCheckerAvailableContext(additionalState = true) {
-  const available = checkerAvailable() && additionalState;
+export async function setCheckerAvailableContext(additionalState = true) {
+  const available = await checkerAvailable() && additionalState;
   commands.executeCommand(`setContext`, CHECKER_AVAILABLE_CONTEXT, available);
 }
 
@@ -81,10 +81,10 @@ export const problemProvider: Disposable[] = [
     }
   }),
 
-  workspace.onDidOpenTextDocument(e => {
+  workspace.onDidOpenTextDocument(async e => {
     const isSql = e.languageId === `sql`;
     if (isSql) {
-      if (checkerAvailable() && !isSafeDocument(e)) {
+      if (await checkerAvailable() && !isSafeDocument(e)) {
         const basename = e.fileName ? path.basename(e.fileName) : `Untitled`;
         documentLargeError(basename);
       }
@@ -108,9 +108,9 @@ export const problemProvider: Disposable[] = [
     }
   }),
 
-  window.onDidChangeActiveTextEditor(e => {
+  window.onDidChangeActiveTextEditor(async e => {
     const canRun = e && e.document.languageId === `sql` && isSafeDocument(e.document);
-    setCheckerAvailableContext(canRun);
+    await setCheckerAvailableContext(canRun);
   }),
 ];
 
@@ -119,7 +119,7 @@ interface SqlDiagnostic extends Diagnostic {
 }
 
 async function validateSqlDocument(document: TextDocument, specificStatement?: number) {
-  const checker = SQLStatementChecker.get();
+  const checker = await SQLStatementChecker.get();
   const job = remoteAssistIsEnabled(true);
   if (checker && job) {
     const basename = document.fileName ? path.basename(document.fileName) : `Untitled`;

--- a/src/language/providers/statusProvider.ts
+++ b/src/language/providers/statusProvider.ts
@@ -12,9 +12,9 @@ export class Db2StatusProvider extends Disposable {
     this.setState(false);
   }
 
-  setState(hasJob: Boolean) {
+  async setState(hasJob: Boolean) {
     if (hasJob) {
-      const checker = SQLStatementChecker.get();
+      const checker = await SQLStatementChecker.get();
       const checkerTimeout = getCheckerTimeout() / 1000;
       this.item.text = `SQL assistance available. ${checker ? `Syntax checking enabled (every ${checkerTimeout}s after editing)` : `Syntax checking not available.`}`;
       this.item.detail = `You're connected to an IBM i. ${checker ? `You can use the advanced SQL language tooling.` : `Syntax checking not available. This means that the syntax checker did not install when connecting to this system.`}`;


### PR DESCRIPTION
### Changes

This depends on Code for IBM i 3.0.0 being release first.

Code for IBM i's `getComponent` returns a `Promise` in `3.0.0` so we should make use of `await` when retrieving it.