### PR TITLE
Add `Statement` and `DbCache` to exported API

### DIFF
--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -1,7 +1,6 @@
 
 import { getInstance } from "../base";
 import Configuration from "../configuration";
-import { JobManager } from "../config";
 
 import {format, FormatOptionsWithLanguage, IdentifierCase, KeywordCase} from "sql-formatter"
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import Configuration from "./configuration";
 import { SQLJobManager } from "./connection/manager";
 import { ServerComponent } from "./connection/serverComponent";
 import { OldSQLJob } from "./connection/sqlJob";
+import Statement from "./database/statement";
 import { languageInit } from "./language/providers";
 import { DbCache } from "./language/providers/logic/cache";
 import { setCheckerAvailableContext } from "./language/providers/problemProvider";
@@ -32,6 +33,8 @@ export interface Db2i {
   sqlJobManager: SQLJobManager,
   sqlJob: (options?: JDBCOptions) => OldSQLJob
   sqlExamples: typeof SQLExamples,
+  statement: typeof Statement,
+  dbCache: typeof DbCache,
 }
 
 // this method is called when your extension is activated
@@ -121,7 +124,9 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   return {
     sqlJobManager: JobManager,
     sqlJob: (options?: JDBCOptions) => new OldSQLJob(options),
-    sqlExamples: SQLExamples
+    sqlExamples: SQLExamples,
+    statement: Statement,
+    dbCache: DbCache
   };
 }
 


### PR DESCRIPTION
This PR adds the `Statement` and `DbCache` to exported API so it can be used by other extensions