### PR TITLE
Improve column content assist metadata for SQL and system names

### DIFF
--- a/.bob/user/skills/create-pr/SKILL.md
+++ b/.bob/user/skills/create-pr/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: create-pr
+description: Create a PR from the working tree
+metadata:
+    user-invocable: true
+    disable-model-invocation: true
+---
+
+Please create a PR from my branch using the GitHub CLI (`gh`). Push the branch if I have not pushed it. If I'm not in a branch for this fix, then create a branch and push that.
+
+If I provide an issue number, the issue belongs to the codefori/vscode-db2i repository. Use this command to find out the info for it: gh issue view <ISSUENUMBER> -R codefori/vscode-db2i
+
+When creating the issue body, mention in the PR "Closes <link to issue>" in the related issue section.
+
+Please use the PR template when creating the PR: .github/PULL_REQUEST_TEMPLATE.md

--- a/.bob/user/skills/issue/SKILL.md
+++ b/.bob/user/skills/issue/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: issue
+description: Use this when working with GitHub issues
+metadata:
+    user-invocable: true
+    disable-model-invocation: true
+---
+
+If figuring out what to work on, then use: gh issue list -R codefori/vscode-db2i 
+
+If the you know what issue number to work on, then use: gh issue view <ISSUENUMBER> -R codefori/vscode-db2i
+
+Ask the user any clarifying questions.
+
+Do not make any commits or branches. Let the user handle committing.

--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -58,8 +58,11 @@ const completionTypes: { [index: string]: CompletionType } = {
 
 
 function getColumnAttributes(column: TableColumn, useSystemName: boolean): string {
+  const shownName = useSystemName ? column.SYSTEM_COLUMN_NAME : column.COLUMN_NAME;
+  const alternateName = useSystemName ? column.COLUMN_NAME : column.SYSTEM_COLUMN_NAME;
   const lines: string[] = [
-    `Column: ${useSystemName ? column.SYSTEM_COLUMN_NAME : column.COLUMN_NAME}`,
+    `Column: ${shownName}`,
+    `${useSystemName ? `SQL name` : `System name`}: ${alternateName}`,
     `Type: ${prepareParamType(column)}`,
     `HAS_DEFAULT: ${column.HAS_DEFAULT}`,
     `IS_IDENTITY: ${column.IS_IDENTITY}`,


### PR DESCRIPTION
## Related issue
Closes https://github.com/codefori/vscode-db2i/issues/528

## Description
- show the alternate column name in content assist metadata
- show the SQL name when system names are used
- show the system name when SQL names are used

## Testing
- npm test
