### PR TITLE
fix: Status Bar Commit button was calling ROLLBACK instead of COMMIT

### DIFF
--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -242,9 +242,9 @@ export class JobManagerView implements TreeDataProvider<any> {
         let selected = id ? JobManager.getJob(id) : JobManager.getSelection();
         if (selected) {
           if (selected.job.underCommitControl()) {
-            const result = await selected.job.endTransaction(TransactionEndType.ROLLBACK);
+            const result = await selected.job.endTransaction(TransactionEndType.COMMIT);
             if (!result.success) {
-              vscode.window.showErrorMessage(`Failed to commit.` + result.error);
+              vscode.window.showErrorMessage(`Failed to commit. ` + result.error);
             }
 
             this.refresh();


### PR DESCRIPTION
## Description

The **Commit** button in the Status Bar was silently performing a **ROLLBACK** instead of a **COMMIT**. This was a copy-paste error in the `jobCommit` command registration — `TransactionEndType.ROLLBACK` was used where `TransactionEndType.COMMIT` was intended.

## Changes

- Fixed `vscode-db2i.jobManager.jobCommit` command to use `TransactionEndType.COMMIT` instead of `TransactionEndType.ROLLBACK`

## Related Issue

Closes https://github.com/codefori/vscode-db2i/issues/465

## Testing

1. Set `Auto commit` = false, `Transaction isolation` = any non-autocommit value
2. Execute a DML statement (INSERT/UPDATE/DELETE)
3. Observe the Status Bar shows a pending transaction indicator
4. Click **Commit** in the Status Bar tooltip
5. Verify the transaction is committed (not rolled back)