### PR TITLE
Fix validate_statement to not rely on hardcoded library

### DIFF
--- a/src/connection/components/validateStatement.ts
+++ b/src/connection/components/validateStatement.ts
@@ -79,7 +79,8 @@ export class ValidateStatementComponent implements IBMiComponent {
       const tempSourcePath = posix.join(tempDir, `sqlvalidator.sql`);
       const srcPath = tempSourcePath ? tempSourcePath : '';
       const library = this.getLibrary(connection);
-      await connection.getContent().writeStreamfileRaw(srcPath, this.getSource(library, ValidateStatementComponent.VERSION));
+      const oldLib = (await connection.runSQL('VALUES CURRENT PATH'))[0]['00001'] as string;
+      await connection.getContent().writeStreamfileRaw(srcPath, this.getSource(library, ValidateStatementComponent.VERSION, oldLib));
       const result = await connection.runCommand({
         command: `QSYS/RUNSQLSTM SRCSTMF('${tempSourcePath}') COMMIT(*NONE) NAMING(*SYS) DFTRDBCOL(${library})`,
         cwd: `/`,
@@ -117,8 +118,9 @@ export class ValidateStatementComponent implements IBMiComponent {
 
 
 
-  private getSource(library: string, version: number) {
+  private getSource(library: string, version: number, oldLib: string) {
     return /*sql*/`
+    SET PATH = ${library};
     create or replace function ${library}.${ValidateStatementComponent.FUNCTION_NAME}(statementText char(${VALID_STATEMENT_LENGTH}) FOR SBCS DATA)
     returns table (
       messageFileName char(10),
@@ -226,6 +228,8 @@ export class ValidateStatementComponent implements IBMiComponent {
     end;
   
     comment on function ${library}/${ValidateStatementComponent.FUNCTION_NAME} is '${version} - SQL Syntax Checker';
+
+    SET PATH = ${oldLib};
     `;
   }
 }

--- a/src/connection/components/validateStatement.ts
+++ b/src/connection/components/validateStatement.ts
@@ -42,8 +42,8 @@ export interface SqlSyntaxError {
 
 export class ValidateStatementComponent implements IBMiComponent {
   static ID = "ValidateStatement";
-  private static readonly VERSION = 1;
-  private static readonly SIGNATURE = "4DA5046C8080EC338A7516B9589CACDBED20A44C7D4BAFFEEC605FFB7C2EDD47";
+  private static readonly VERSION = 2;
+  private static readonly SIGNATURE = "6EBAA79B92569974227D1A9CCFBF78439DBA1E2EABBAB3CABFC8962C25BC6647";
   private static readonly FUNCTION_NAME = `VALIDATE_STATEMENT${ValidateStatementComponent.VERSION.toString().padStart(4, "0")}`;
 
   static async get(): Promise<ValidateStatementComponent | undefined> {
@@ -174,7 +174,7 @@ export class ValidateStatementComponent implements IBMiComponent {
       set options = x'00000001' concat x'00000001' concat x'0000000A' concat '*NONE     '; --No naming convention
       -- set options = x'00000001' concat x'00000008' concat x'00000004' concat x'000004B0'; -- ccsid
       
-      call ${library}.${CheckStatementComponent.FUNCTION_NAME}( statementText, stmtLength, recordsProvided, statementLanguage, options, statementInfo, statementInfoLength, recordsProcessed, errorCode);
+      call ${CheckStatementComponent.FUNCTION_NAME}( statementText, stmtLength, recordsProvided, statementLanguage, options, statementInfo, statementInfoLength, recordsProcessed, errorCode);
     
       -- Parse the output
       set messageFileName = rtrim(substr(statementInfo, 1, 10));


### PR DESCRIPTION
### Changes
Fixes #549, the validate statement component was using a hardcoded library in the source. We have removed the  qualifier so it uses the default library of the RUNSQLSTM job (which is already set properly) 

### How to test this PR
1. Connect to a system where the temp library is not ILEDITOR
2. Once connected edit an SQL file to trigger the syntax checker

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
