### PR TITLE
Use Core SQL signature check

### DIFF
--- a/src/connection/components/checkStatement.ts
+++ b/src/connection/components/checkStatement.ts
@@ -7,7 +7,7 @@ export class CheckStatementComponent implements IBMiComponent {
   static ID = "CheckStatementComponent";
   private static readonly VERSION = 1;
   static readonly FUNCTION_NAME = `CHKSTMNT${CheckStatementComponent.VERSION.toString().padStart(4, "0")}`;
-  private static readonly SIGNATURE = "7CDD7F08E0CE36EF271A81197C2D770CBBD3A3AA2E02D3217421995EA555A7F0";
+  private static readonly SIGNATURE = "QSYS/QSQCHKS";
   private static readonly VALID_STATEMENT_LENGTH = 32740;
   private static readonly TYPE = "PROCEDURE";
 
@@ -24,8 +24,7 @@ export class CheckStatementComponent implements IBMiComponent {
   }
 
   async getRemoteState(connection: IBMi, installDirectory: string): Promise<SecureComponentState> {
-    const remoteSignature = await this.getSQLRoutineSignature(
-      connection,
+    const remoteSignature = await connection.getContent().getSQLRoutineSignature(
       this.getLibrary(connection),
       CheckStatementComponent.FUNCTION_NAME,
       CheckStatementComponent.TYPE,
@@ -34,15 +33,6 @@ export class CheckStatementComponent implements IBMiComponent {
       status: remoteSignature ? "Installed" : "NotInstalled",
       remoteSignature: remoteSignature,
     };
-  }
-
-  /**
-   * Custom implementation that uses EXTERNAL_NAME instead of ROUTINEDEF
-   */
-  private async getSQLRoutineSignature(connection: IBMi, library: string, name: string, type: "PROCEDURE" | "FUNCTION") {
-    return (await connection.runSQL(
-      /* sql */`select HASH_SHA256(EXTERNAL_NAME) SIGNATURE from qsys2.sysroutines where routine_type = '${type}' and rtnschema = '${library}' and RTNNAME = '${name}' fetch first row only`
-    )).pop()?.SIGNATURE as string;    
   }
 
   async update(connection: IBMi, installDirectory: string): Promise<SecureComponentState> {

--- a/src/connection/components/validateStatement.ts
+++ b/src/connection/components/validateStatement.ts
@@ -43,7 +43,7 @@ export interface SqlSyntaxError {
 export class ValidateStatementComponent implements IBMiComponent {
   static ID = "ValidateStatement";
   private static readonly VERSION = 2;
-  private static readonly SIGNATURE = "6EBAA79B92569974227D1A9CCFBF78439DBA1E2EABBAB3CABFC8962C25BC6647";
+  private static readonly SIGNATURE = "1937A5AE221BD126F8514798721DFC7F1259CAA9018443ABE38CCF735F48073C";
   private static readonly FUNCTION_NAME = `VALIDATE_STATEMENT${ValidateStatementComponent.VERSION.toString().padStart(4, "0")}`;
 
   static async get(): Promise<ValidateStatementComponent | undefined> {


### PR DESCRIPTION
### Changes
This PR uses the updated version of the `getSQLRoutineSignature` method to verify the signatures of SQL objects.
In the `CheckStatement` file, the signature (the program name, since it is an external procedure) has been updated and the local method has been removed; in the `ValidateStatement` file, only the signature has been updated (due to the change in algorithm).

### How to test this PR
**To test this PR, you must have the Core version with PR https://github.com/codefori/vscode-ibmi/pull/3328 installed locally.**

Connect to the system; there should be no warnings regarding the two SQL objects. 

**The DB2 version must be released alongside the Core version**

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
