### PR TITLE
Add joblog in self view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1620,11 +1620,6 @@
           "group": "inline@1"
         },
         {
-          "command": "vscode-db2i.self.viewJobLog",
-          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
-          "group": "navigation"
-        },
-        {
           "command": "vscode-db2i.examples.edit",
           "when": "view == exampleBrowser && viewItem == example.custom",
           "group": "0_open"

--- a/package.json
+++ b/package.json
@@ -987,6 +987,12 @@
         "enablement": "vscode-db2i:continueExtensionActive"
       },
       {
+        "command": "vscode-db2i.self.viewJobLog",
+        "title": "View Job Log",
+        "category": "Db2 for i",
+        "icon": "$(info)"
+      },
+      {
         "command": "vscode-db2i.self.help",
         "title": "Open SELF Documentation",
         "category": "Db2 for i",
@@ -1606,6 +1612,16 @@
         {
           "command": "vscode-db2i.self.explainSelf",
           "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeNode && vscode-db2i:continueExtensionActive",
+          "group": "navigation"
+        },
+        {
+          "command": "vscode-db2i.self.viewJobLog",
+          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
+          "group": "inline@1"
+        },
+        {
+          "command": "vscode-db2i.self.viewJobLog",
+          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
           "group": "navigation"
         },
         {

--- a/src/views/jobManager/selfCodes/contributes.json
+++ b/src/views/jobManager/selfCodes/contributes.json
@@ -88,6 +88,12 @@
         "enablement": "vscode-db2i:continueExtensionActive"
       },
       {
+        "command": "vscode-db2i.self.viewJobLog",
+        "title": "View Job Log",
+        "category": "Db2 for i",
+        "icon": "$(info)"
+      },
+      {
         "command": "vscode-db2i.self.help",
         "title": "Open SELF Documentation",
         "category": "Db2 for i",
@@ -146,6 +152,16 @@
         {
           "command": "vscode-db2i.self.explainSelf",
           "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeNode && vscode-db2i:continueExtensionActive",
+          "group": "navigation"
+        },
+        {
+          "command": "vscode-db2i.self.viewJobLog",
+          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
+          "group": "inline@1"
+        },
+        {
+          "command": "vscode-db2i.self.viewJobLog",
+          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
           "group": "navigation"
         }
       ]

--- a/src/views/jobManager/selfCodes/contributes.json
+++ b/src/views/jobManager/selfCodes/contributes.json
@@ -158,11 +158,6 @@
           "command": "vscode-db2i.self.viewJobLog",
           "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
           "group": "inline@1"
-        },
-        {
-          "command": "vscode-db2i.self.viewJobLog",
-          "when": "view == vscode-db2i.self.nodes && viewItem == selfCodeJob",
-          "group": "navigation"
         }
       ]
     }

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -68,10 +68,8 @@ export class SelfCodesResultsView implements TreeDataProvider<any> {
           await vscode.window.showTextDocument(document, { preview: false });
         }
       }),
-      vscode.commands.registerCommand(`vscode-db2i.self.viewJobLog`, async (item: SelfErrorJobItem | SelfCodeTreeItem | string) => {
-        const jobName = typeof item === `string`
-          ? item
-          : (item instanceof SelfErrorJobItem ? item.jobName : item?.error?.JOB_NAME);
+      vscode.commands.registerCommand(`vscode-db2i.self.viewJobLog`, async (item: SelfErrorJobItem | string) => {
+        const jobName = typeof item === `string` ? item : item.jobName;
 
         if (jobName) {
           try {

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -68,6 +68,19 @@ export class SelfCodesResultsView implements TreeDataProvider<any> {
           await vscode.window.showTextDocument(document, { preview: false });
         }
       }),
+      vscode.commands.registerCommand(`vscode-db2i.self.viewJobLog`, async (item: SelfErrorJobItem | SelfCodeTreeItem | string) => {
+        const jobName = typeof item === `string`
+          ? item
+          : (item instanceof SelfErrorJobItem ? item.jobName : item?.error?.JOB_NAME);
+
+        if (jobName) {
+          try {
+            await vscode.commands.executeCommand(`code-for-ibmi.showJobLog`, jobName);
+          } catch (e) {
+            vscode.window.showErrorMessage(`Unable to open the job log for ${jobName}: ${e}`);
+          }
+        }
+      }),
       vscode.commands.registerCommand(`vscode-db2i.self.help`, async () => {
         await vscode.commands.executeCommand(`vscode.open`, `https://www.ibm.com/docs/en/i/7.5?topic=tools-sql-error-logging-facility-self`)
       }),
@@ -109,7 +122,7 @@ export class SelfCodesResultsView implements TreeDataProvider<any> {
     const content = `SELECT 
                       job_name, user_name, reason_code, logged_time, logged_sqlstate, logged_sqlcode, matches, stmttext, message_text, message_second_level_text,
                       program_library, program_name, program_type, module_name, client_applname, client_programid, initial_stack
-                    FROM qsys2.sql_error_log, lateral (select * from TABLE(SYSTOOLS.SQLCODE_INFO(logged_sqlcode)))
+                    FROM qsys2.sql_error_log x, lateral (select * from TABLE(SYSTOOLS.SQLCODE_INFO(x.logged_sqlcode)))
                     where user_name = current_user 
                     and ${onlySelected ? `job_name = '${selected.job.id}'` : `LOGGED_TIME >= (select JOB_ENTERED_SYSTEM_TIME from table(qsys2.active_job_info('NO', job_name_filter => '*', detailed_info => 'WORK')) x) `}
                     order by logged_time desc`;
@@ -251,10 +264,10 @@ export class SelfCodeTreeItem extends ExtendedTreeItem {
 
     const items: ExtendedTreeItem[] = [
       new SelfErrorStatementItem(this.error.STMTTEXT),
-      new SelfErrorNodeItem(`Job`, this.error.JOB_NAME),
-      new SelfErrorNodeItem(`Client Name`, this.error.CLIENT_APPLNAME),
-      new SelfErrorNodeItem(`Client Program`, this.error.CLIENT_PROGRAMID),
-      new SelfErrorNodeItem(`Object`, `${this.error.PROGRAM_LIBRARY}/${this.error.PROGRAM_NAME} (${this.error.PROGRAM_TYPE}, ${this.error.MODULE_NAME})`),
+      new SelfErrorJobItem(this.error.JOB_NAME),
+      new SelfErrorNodeItem(`Client Name`, this.error.CLIENT_APPLNAME, `account`),
+      new SelfErrorNodeItem(`Client Program`, this.error.CLIENT_PROGRAMID, `file-code`),
+      new SelfErrorNodeItem(`Object`, `${this.error.PROGRAM_LIBRARY}/${this.error.PROGRAM_NAME} (${this.error.PROGRAM_TYPE}, ${this.error.MODULE_NAME})`, `symbol-field`),
     ]
 
     if (validStack.length > 0) {
@@ -336,10 +349,31 @@ class SelfErrorStatementItem extends ExtendedTreeItem {
 }
 
 class SelfErrorNodeItem extends ExtendedTreeItem {
-  constructor(label: string, description: string) {
+  constructor(label: string, description: string, icon = `info`) {
     super(label, vscode.TreeItemCollapsibleState.None);
-    this.iconPath = new vscode.ThemeIcon(`info`);
+    // Explicit colour so symbol icons don't pick up their default (blue) tint
+    this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(`icon.foreground`));
     this.description = description;
+  }
+
+  async getChildren(): Promise<ExtendedTreeItem[]> {
+    return [];
+  }
+}
+
+class SelfErrorJobItem extends ExtendedTreeItem {
+  constructor(public jobName: string) {
+    super(`Job`, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(`briefcase`, new vscode.ThemeColor(`icon.foreground`));
+    this.description = jobName;
+    this.tooltip = new vscode.MarkdownString(`Open the job log for \`${jobName}\``);
+    this.contextValue = `selfCodeJob`;
+
+    this.command = {
+      command: `vscode-db2i.self.viewJobLog`,
+      title: `View Job Log`,
+      arguments: [jobName]
+    };
   }
 
   async getChildren(): Promise<ExtendedTreeItem[]> {


### PR DESCRIPTION
### Changes
This PR allows you to view the job log directly from the SELF view.

### How to test this PR
Connect to a system, open an .sql file, and enter an incorrect query to generate a log in SELF (make sure SELF is enabled).
In the error details table, click the job name or the info icon next to the job name; the job log option will open.

<img width="760" height="189" alt="image" src="https://github.com/user-attachments/assets/d7c07671-a103-4aff-b825-6521e3fc1203" />


### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Closes #246 